### PR TITLE
fix(ci): migrate cleanup-smoke-users workflow to pnpm

### DIFF
--- a/.github/workflows/cleanup-smoke-users.yml
+++ b/.github/workflows/cleanup-smoke-users.yml
@@ -9,11 +9,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check lockfile exists
+        run: test -f pnpm-lock.yaml
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.9
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npx tsx scripts/cleanup-smoke-users.ts
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec tsx scripts/cleanup-smoke-users.ts
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}


### PR DESCRIPTION
## Summary
- Replace npm ci with pnpm install --frozen-lockfile.
- Replace npx tsx with pnpm exec tsx.
- Add pnpm setup/cache so the scheduled cleanup job runs with the project package manager.
- Fix scheduled job failure in main branch.