### PR TITLE
fix(ci): align cleanup workflow pnpm version

### DIFF
--- a/.github/workflows/cleanup-smoke-users.yml
+++ b/.github/workflows/cleanup-smoke-users.yml
@@ -13,7 +13,7 @@ jobs:
         run: test -f pnpm-lock.yaml
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- Align cleanup-smoke-users pnpm/action-setup version with main packageManager pnpm@9.
- Fix manual workflow failure caused by pnpm/action-setup rejecting mixed pnpm versions.
- Keep scope limited to cleanup-smoke-users workflow.