### PR TITLE
fix(ci): support SUPABASE_URL cleanup secret

### DIFF
--- a/.github/workflows/cleanup-smoke-users.yml
+++ b/.github/workflows/cleanup-smoke-users.yml
@@ -22,5 +22,5 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec tsx scripts/cleanup-smoke-users.ts
         env:
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL || secrets.VITE_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/scripts/cleanup-smoke-users.ts
+++ b/scripts/cleanup-smoke-users.ts
@@ -7,11 +7,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../.env.local") });
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL || "";
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "";
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
 
 if (!supabaseUrl || !serviceRoleKey) {
-  console.error("❌ Faltan variables de entorno de Supabase.");
+  console.error("❌ Faltan variables de entorno de Supabase: SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY.");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Use `SUPABASE_URL` as the canonical Actions secret for cleanup-smoke-users.
- Keep `VITE_SUPABASE_URL` as a fallback for existing configurations.
- Clarify the missing-secret error message in the cleanup script.

## Verification
- `pnpm test` ran from the pre-commit hook: 34 tests passed.
- `CI=true git push` ran the pre-push hook: `pnpm@9 install --frozen-lockfile` and `tsc --noEmit` passed.
- Script-specific TypeScript check passed with `--skipLibCheck`; the check without it was blocked by upstream Supabase realtime declaration resolution.