### PR TITLE
fix(ci): skip cleanup when secrets are missing

### DIFF
--- a/scripts/cleanup-smoke-users.ts
+++ b/scripts/cleanup-smoke-users.ts
@@ -11,8 +11,8 @@ const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL ||
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
 
 if (!supabaseUrl || !serviceRoleKey) {
-  console.error("❌ Faltan variables de entorno de Supabase: SUPABASE_URL y SUPABASE_SERVICE_ROLE_KEY.");
-  process.exit(1);
+  console.warn("Skipping cleanup: missing env vars");
+  process.exit(0);
 }
 
 const admin = createClient(supabaseUrl, serviceRoleKey, {


### PR DESCRIPTION
## Summary
- Make cleanup-smoke-users skip safely when Supabase secrets are missing.
- Prevent scheduled/manual CI failures caused only by deleted or unavailable Supabase secrets.

## Verification
- Missing-env execution: `Skipping cleanup: missing env vars` and successful exit.
- Pre-commit hook: `pnpm test` passed, 34 tests.
- Pre-push hook: `pnpm@9 install --frozen-lockfile` and `tsc --noEmit` passed.