### PR TITLE
fix(ci): migrate Visual QA workflow to pnpm

### DIFF
--- a/.github/workflows/visual-qa.yml
+++ b/.github/workflows/visual-qa.yml
@@ -8,7 +8,7 @@ on:
       - "src/**"
       - "tests/visual-glass-smoke.js"
       - "package.json"
-      - "package-lock.json"
+      - "pnpm-lock.yaml"
       - "vite.config.ts"
       - "tailwind.config.js"
       - "src/index.css"
@@ -25,18 +25,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "20"
-          cache: "npm"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
-        run: HUSKY=0 npm ci
+        run: HUSKY=0 pnpm install --frozen-lockfile
 
       - name: Start Vite
-        run: nohup npm run dev -- --host 127.0.0.1 > visual-qa-vite.log 2>&1 &
+        run: nohup pnpm dev -- --host 127.0.0.1 > visual-qa-vite.log 2>&1 &
 
       - name: Wait for app
         run: |


### PR DESCRIPTION
## Summary
- Migrate Visual QA from npm lockfile/install flow to pnpm.
- Add pnpm/action-setup and pnpm cache configuration.
- Run Vite with pnpm so the workflow matches the repository package manager.

## Verification
- Diff is limited to `.github/workflows/visual-qa.yml`.
- This directly addresses the prior Visual QA failure: setup-node was using `cache: npm` and expected `package-lock.json` in a PNPM repo.