### PR TITLE
chore(ci): migrate workflows to Node 24

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/cleanup-smoke-users.yml
+++ b/.github/workflows/cleanup-smoke-users.yml
@@ -11,13 +11,13 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check lockfile exists
         run: test -f pnpm-lock.yaml
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/cleanup-smoke-users.yml
+++ b/.github/workflows/cleanup-smoke-users.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 0 * * *' # Cada medianoche
   workflow_dispatch: # Permitir ejecución manual
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -16,7 +19,7 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/sase-secure-pipeline.yml
+++ b/.github/workflows/sase-secure-pipeline.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 📦 Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/sase-secure-pipeline.yml
+++ b/.github/workflows/sase-secure-pipeline.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: secure-pipeline-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,7 +31,7 @@ jobs:
       - name: 🟢 Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
 
       - name: 🔒 Install Dependencies (Strict)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, master, develop]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: security-check-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/visual-qa.yml
+++ b/.github/workflows/visual-qa.yml
@@ -13,6 +13,9 @@ on:
       - "tailwind.config.js"
       - "src/index.css"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: visual-qa-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -33,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/visual-qa.yml
+++ b/.github/workflows/visual-qa.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 


### PR DESCRIPTION
## Summary
- Move GitHub workflow runtime setup from Node 20 to Node 24.
- Enable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` across workflows to opt into GitHub's upcoming JS action runtime.
- Keep PNPM install/test/build commands unchanged.

## Verification
- Diff is limited to `.github/workflows`.
- `git diff --check` passed.