### PR TITLE
feat(orientacion): v2 backend + dashboard (expediente, diagnosticos, intervencion)

### DIFF
--- a/specs/006-orientacion-v2/plan.md
+++ b/specs/006-orientacion-v2/plan.md
@@ -1,0 +1,33 @@
+# Plan - Orientacion v2
+
+## Fase 0. Diagnostico
+
+- Confirmar tablas existentes y politicas RLS.
+- Identificar reutilizacion y gaps sin duplicar dominios.
+
+## Fase 1. Backend Supabase
+
+- Crear migracion no destructiva.
+- Agregar tablas minimas, constraints, indices FK y RLS.
+- Agregar RPCs para abrir caso, solicitar diagnostico, registrar diagnostico, crear plan, derivar y escalar.
+
+## Fase 2. Frontend
+
+- Crear `src/components/orientacion/` con componentes de bandeja, detalle, historial, diagnosticos, plan, seguimiento, insights y reporte.
+- Reemplazar `DashboardOrientacion.tsx` sin usar `addIncident`.
+
+## Fase 3. Tipos y permisos
+
+- Actualizar tipos Supabase manuales para las tablas/RPCs nuevas.
+- Ajustar permisos de Orientacion para no cierre final.
+
+## Fase 4. Validacion
+
+- Ejecutar type-check, build y tests.
+- Ejecutar auditoria/lint Supabase si el entorno local de Docker/Supabase esta disponible.
+
+## Riesgos
+
+- Las vistas actuales dependen de RLS de tablas base; cualquier apertura amplia existente sigue siendo riesgo heredado.
+- Los tipos generados estaban desincronizados con el esquema remoto en `respuestas_docentes`; el cambio evita depender de esa tabla.
+- Supabase Branching no esta disponible por plan Pro, asi que la validacion sera local/CI gratuita.

--- a/specs/006-orientacion-v2/quickstart.md
+++ b/specs/006-orientacion-v2/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart - Orientacion v2
+
+## Verificacion frontend
+
+```bash
+pnpm install --frozen-lockfile
+pnpm type-check
+pnpm build
+pnpm test
+```
+
+## Verificacion Supabase local
+
+```bash
+./scripts/audit-migrations.sh
+supabase db start
+supabase db lint --local
+```
+
+## Flujo funcional esperado
+
+1. Orientacion abre un caso de alumno en riesgo.
+2. Orientacion solicita diagnostico a docente asignado.
+3. Docente responde solo su solicitud.
+4. Orientacion crea plan de intervencion.
+5. Orientacion deriva a Trabajo Social o escala a Direccion.
+6. Toda mutacion registra auditoria.

--- a/specs/006-orientacion-v2/research.md
+++ b/specs/006-orientacion-v2/research.md
@@ -1,0 +1,29 @@
+# Research - Orientacion v2
+
+## Diagnostico de tablas existentes
+
+- `alumnos`: fuente institucional de alumno, grupo, matricula, semaforo y riesgo persistido.
+- `incidencias`: historial de eventos reportados; se consulta para contexto, no se crea desde Orientacion.
+- `expediente_integral_alumno`: vista `security_invoker` que consolida trayectoria institucional.
+- `alumnos_en_riesgo`: vista de deteccion temprana, util para priorizar bandeja.
+- `citas_padres`: citatorios legacy; se conserva como apoyo, no como caso de Orientacion.
+- `contacts_log`: contactos familiares legacy; se conserva como evidencia auxiliar.
+- `interventions_log`: bitacora legacy de intervenciones; insuficiente para plan, estado y RLS de caso.
+- `seguimiento_social`: dominio de Trabajo Social; no se mezcla con Orientacion.
+- `respuestas_docentes`: respuestas colectivas/legacy; no modela solicitud individual asignada por caso.
+- `solicitudes`: solicitudes genericas; carece de `caso_id` y contrato de diagnostico docente.
+
+## Gap real
+
+No existe equivalente a caso de Orientacion, solicitud docente asignada, diagnostico individual por caso, plan de intervencion ni seguimiento propio con evidencia.
+
+## Decision
+
+Crear solo cinco tablas nuevas: `orientacion_casos`, `solicitudes_diagnostico`, `diagnosticos_docentes`, `planes_intervencion` y `seguimiento_orientacion`.
+
+## Seguridad
+
+- RLS activado en todas las tablas nuevas.
+- RPCs `security invoker`; no se introduce `service_role` en frontend.
+- Auditoria mediante `public.auditoria` con rol obtenido desde `perfiles_usuario`.
+- Direccion/Subdireccion leen, Orientacion muta sus casos, docentes responden asignaciones, Trabajo Social lee derivados.

--- a/specs/006-orientacion-v2/spec.md
+++ b/specs/006-orientacion-v2/spec.md
@@ -1,0 +1,38 @@
+# Spec - Orientacion v2
+
+## Problema
+
+Orientacion opera hoy sobre una UI legacy que mezcla alumnos en riesgo, citatorios e intervenciones, pero no tiene caso institucional persistente, solicitud docente asignada, plan de intervencion ni bitacora propia con evidencia. Esto impide defender decisiones ante Direccion, supervision o familias sin depender de incidencias o seguimiento social.
+
+## Alcance
+
+- Backend base Supabase para casos de Orientacion.
+- RLS fail-closed por rol institucional real.
+- RPCs institucionales para mutaciones con auditoria.
+- Dashboard Orientacion v2 mobile-first.
+- Reutilizacion de `alumnos`, `incidencias`, vistas de expediente, `citas_padres`, `contacts_log`, `interventions_log` y `seguimiento_social` sin duplicar su dominio.
+
+## Fuera de alcance
+
+- Crear incidencias desde Orientacion.
+- Cerrar casos finales como Direccion.
+- Ejecutar visitas domiciliarias.
+- Reemplazar Trabajo Social o seguimiento social.
+- Cambiar autenticacion.
+
+## Reglas funcionales
+
+- Orientacion abre, analiza, solicita diagnosticos, define planes, deriva a Trabajo Social y escala a Direccion.
+- Docentes solo responden diagnosticos asignados.
+- Trabajo Social solo ve casos derivados a su area.
+- Direccion y Subdireccion ven todos los casos para supervision institucional.
+- `developer` y `system_admin` tienen acceso completo.
+
+## Validacion
+
+- `pnpm type-check`
+- `pnpm build`
+- `pnpm test`
+- `./scripts/audit-migrations.sh`
+- `supabase db start`
+- `supabase db lint --local`

--- a/specs/006-orientacion-v2/tasks.md
+++ b/specs/006-orientacion-v2/tasks.md
@@ -1,0 +1,11 @@
+# Tasks - Orientacion v2
+
+- [x] Diagnosticar tablas existentes y RLS.
+- [x] Definir extension minima no duplicada.
+- [ ] Crear migracion Supabase con RLS y RPCs.
+- [ ] Crear servicio frontend para RPCs.
+- [ ] Crear componentes `src/components/orientacion/`.
+- [ ] Reemplazar dashboard legacy de Orientacion.
+- [ ] Actualizar permisos y tipos.
+- [ ] Actualizar tests.
+- [ ] Ejecutar validaciones.

--- a/src/components/dashboards/DashboardOrientacion.tsx
+++ b/src/components/dashboards/DashboardOrientacion.tsx
@@ -1,373 +1,310 @@
-import React, { useState, useEffect } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { useApp } from "../../store";
-import { CaseState, AppModule, Protocol, CaseLabels } from "../../types";
-import { supabase } from "../../supabase/client";
-import { ProtocolDetailModal } from "../Protocols/ProtocolDetailModal";
-import { GenericActionModal } from "../GenericActionModal";
-import { useAuth } from "../AuthProvider";
-import { StudentAdvancedPanel } from "../StudentAdvancedPanel";
-import { PrintPreviewModal } from "../PrintPreviewModal";
+import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
+import { useApp } from "../../store";
+import { useAuth } from "../AuthProvider";
 import { GlassCard } from "../ui/GlassCard";
-import { NeoButton } from "../ui/NeoButton";
-import { getStatusColors } from "../../utils/statusUtils";
+import { OrientacionRoleHeader } from "../orientacion/OrientacionRoleHeader";
+import { OrientacionInsights } from "../orientacion/OrientacionInsights";
+import { OrientacionCaseInbox } from "../orientacion/OrientacionCaseInbox";
+import { OrientacionCaseDetail } from "../orientacion/OrientacionCaseDetail";
+import { StudentInstitutionalHistory } from "../orientacion/StudentInstitutionalHistory";
+import { TeacherDiagnosisRequests } from "../orientacion/TeacherDiagnosisRequests";
+import { InterventionPlanEditor } from "../orientacion/InterventionPlanEditor";
+import { OrientacionFollowUpPanel } from "../orientacion/OrientacionFollowUpPanel";
+import { OrientacionReportPreview } from "../orientacion/OrientacionReportPreview";
+import {
+  abrirCasoOrientacion,
+  crearPlanIntervencion,
+  derivarTrabajoSocial,
+  escalarDireccion,
+  loadDocentes,
+  loadOrientacionCasos,
+  loadStudentHistory,
+  solicitarDiagnostico,
+} from "../orientacion/orientacionApi";
+import type {
+  OrientacionCaseSummary,
+  OrientacionDiagnosisRequest,
+  OrientacionDocenteOption,
+  OrientacionFollowUp,
+  OrientacionHistoryItem,
+  OrientacionPlan,
+  OrientacionStudentSummary,
+} from "../orientacion/orientacionTypes";
+import { supabase } from "../../supabase/client";
+
+type StudentSuggestion = OrientacionStudentSummary & { rawId: string };
 
 export const DashboardOrientacion = () => {
-  const { students, setCurrentModule, addIncident } = useApp();
+  const { students } = useApp();
   const { user } = useAuth();
-  const [supportProtocol, setSupportProtocol] = useState<Protocol | null>(null);
-  const [showProtocol, setShowProtocol] = useState(false);
+  const [cases, setCases] = useState<OrientacionCaseSummary[]>([]);
+  const [docentes, setDocentes] = useState<OrientacionDocenteOption[]>([]);
+  const [selectedCaseId, setSelectedCaseId] = useState<string | null>(null);
+  const [history, setHistory] = useState<{
+    summary: any | null;
+    incidents: OrientacionHistoryItem[];
+    citations: OrientacionHistoryItem[];
+    contacts: OrientacionHistoryItem[];
+    interventions: OrientacionHistoryItem[];
+    teacherReports: OrientacionHistoryItem[];
+    plans: OrientacionPlan[];
+    requests: OrientacionDiagnosisRequest[];
+    followUps: OrientacionFollowUp[];
+  }>({
+    summary: null,
+    incidents: [],
+    citations: [],
+    contacts: [],
+    interventions: [],
+    teacherReports: [],
+    plans: [],
+    requests: [],
+    followUps: [],
+  });
+  const [loading, setLoading] = useState(true);
 
-  const [modalOpen, setModalOpen] = useState<
-    "APPOINTMENT" | "INTERVIEW" | "CONTACT" | null
-  >(null);
-  const [selectedStudent, setSelectedStudent] = useState<any>(null);
-  const [showAdvancedPanel, setShowAdvancedPanel] = useState(false);
-  const [showPrintPreview, setShowPrintPreview] = useState(false);
-  const [previewContent, setPreviewContent] = useState("");
+  const suggestions: StudentSuggestion[] = students
+    .filter((student) => student.caseState !== "CERRADO")
+    .slice(0, 6)
+    .map((student) => ({
+      rawId: student.id,
+      id: student.id,
+      nombre: student.name,
+      grupo: student.group ?? null,
+      matricula: student.matricula ?? null,
+      puntajeRiesgo: student.puntajeRiesgo ?? null,
+      estadoSemaforo: student.estadoSemaforo ?? null,
+    }));
 
-  const highRiskStudents = students.filter(
-    (s) => s.caseState === CaseState.PATRON_DETECTADO || s.caseState === CaseState.INTERVENCION,
-  );
-  
-  const attentionRequired = students.filter(
-    (s) => s.caseState === CaseState.INTERVENCION,
-  ).length;
-  
-  const onObservation = students.filter(
-    (s) => s.caseState === CaseState.OBSERVADO,
-  ).length;
-
-  const handlePrepareBitacora = () => {
-    const html = `
-      <h2>Bitácora Semanal de Orientación</h2>
-      <p><strong>Corte de Caja:</strong> ${new Date().toLocaleDateString()}</p>
-      
-      <h3>Estadísticas de Riesgo</h3>
-      <table>
-        <tr><th>Categoría</th><th>Cantidad</th></tr>
-        <tr><td>Casos en Intervención</td><td>${attentionRequired}</td></tr>
-        <tr><td>Alumnos Observados</td><td>${onObservation}</td></tr>
-        <tr><td>Patrones de Riesgo IA</td><td>${highRiskStudents.length}</td></tr>
-      </table>
-
-      <h3>Resumen de Casos Críticos</h3>
-      <ul>
-        ${highRiskStudents
-          .map(
-            (s) => `
-          <li>
-            <strong>${s.name} (${s.group}):</strong> 
-            Patrón de comportamiento detectado. Requiere seguimiento psicopedagógico inmediato.
-          </li>
-        `,
-          )
-          .join("")}
-      </ul>
-
-      <div style="margin-top: 30px; padding: 15px; border: 1px dashed #ccc; background: #f9f9f9;">
-        <h4>Observaciones de Campo</h4>
-        <p>[Escriba aquí sus observaciones adicionales para el reporte del día...]</p>
-      </div>
-
-      <div class="signature-line">
-        <div class="signature-box">
-          <div class="line"></div>
-          <div class="label">FIRMA DE ORIENTACIÓN / TRABAJO SOCIAL</div>
-        </div>
-      </div>
-    `;
-    setPreviewContent(html);
-    setShowPrintPreview(true);
-  };
-
-  const handleSaveAppointment = async (data: any) => {
-    if (!user) return;
-    const { error } = await supabase.from("citas_padres" as any).insert({
-      creado_por: user.id,
-      alumno_id: data.student,
-      fecha_cita: data.date,
-      motivo: data.reason,
-      estado: "PENDIENTE",
-      observaciones: "Agendado por Orientación",
-    });
-    if (error) {
-      toast.error("Error al agendar cita");
-      throw error;
-    }
-    toast.success("Cita sincronizada con el calendario");
-  };
-
-  const handleSaveInterview = async (data: any) => {
-    if (!user) return;
-    const { error } = await supabase.from("interventions_log" as any).insert({
-      user_id: user.id,
-      student_id: data.student,
-      reason: data.reason,
-      notes: data.notes,
-      result: data.result || "Pendiente",
-    });
-    if (error) {
-      toast.error("Error al registrar entrevista");
-      throw error;
-    }
-    toast.success("Bitácora de entrevista guardada");
-  };
-
-  const handleNotifyAcademicRisk = async (studentId: string, info: string) => {
-    try {
-      await addIncident(
-        studentId,
-        "ACADEMICO" as any,
-        `⚠️ REPORTE ORIENTACIÓN: Se requiere seguimiento especial por ${info}.`,
-      );
-      toast.success("Notificación enviada a la academia", { icon: "📝" });
-    } catch (err) {
-      toast.error("Fallo de comunicación interna");
-    }
-  };
+  const selectedCase = cases.find((item) => item.id === selectedCaseId) ?? cases[0] ?? null;
+  const activeCases = cases.filter((item) => item.estado !== "cerrado").length;
+  const pendingRequests = history.requests.filter((item) => item.estado === "pendiente").length;
+  const criticalCases = cases.filter((item) => item.prioridad === "critica" || item.estado === "escalado_direccion").length;
 
   useEffect(() => {
-    const fetchProtocol = async () => {
-      const { data } = await supabase
-        .from("protocolos" as any)
-        .select("*")
-        .ilike("titulo", "%Violencia Escolar%")
-        .single();
-      if (data) setSupportProtocol(data as any);
+    const load = async () => {
+      try {
+        setLoading(true);
+        const [loadedCases, loadedDocentes] = await Promise.all([loadOrientacionCasos(), loadDocentes()]);
+        setCases(loadedCases);
+        setDocentes(loadedDocentes);
+        setSelectedCaseId((current) => current ?? loadedCases[0]?.id ?? null);
+      } catch (error) {
+        console.error(error);
+        toast.error("No se pudieron cargar los casos de Orientación");
+      } finally {
+        setLoading(false);
+      }
     };
-    fetchProtocol();
+
+    load();
   }, []);
 
+  useEffect(() => {
+    const loadHistory = async () => {
+      if (!selectedCase?.alumnoId) return;
+
+      try {
+        const data = await loadStudentHistory(selectedCase.alumnoId, selectedCase.id);
+        setHistory(data);
+      } catch (error) {
+        console.error(error);
+        toast.error("No se pudo cargar el historial del alumno");
+      }
+    };
+
+    loadHistory();
+  }, [selectedCase?.alumnoId, selectedCase?.id]);
+
+  const refreshCases = async (caseIdToSelect?: string) => {
+    const loadedCases = await loadOrientacionCasos();
+    setCases(loadedCases);
+    setSelectedCaseId(caseIdToSelect ?? loadedCases[0]?.id ?? null);
+    return loadedCases;
+  };
+
+  const handleOpenStudentCase = async (studentId: string) => {
+    const student = suggestions.find((item) => item.rawId === studentId);
+    if (!student) return;
+
+    try {
+      const caseId = await abrirCasoOrientacion({
+        alumnoId: student.rawId,
+        motivo: `Seguimiento preventivo solicitado por Orientación para ${student.nombre}.`,
+        resumen: `Semáforo: ${student.estadoSemaforo ?? "sin dato"}. Puntaje: ${student.puntajeRiesgo ?? 0}.`,
+        prioridad: student.puntajeRiesgo && student.puntajeRiesgo >= 70 ? "alta" : "media",
+      });
+      await refreshCases(caseId);
+      toast.success("Caso de Orientación abierto");
+    } catch (error) {
+      console.error(error);
+      toast.error("No se pudo abrir el caso");
+    }
+  };
+
+  const handleRequestDiagnosis = async (docenteId: string, observaciones: string) => {
+    if (!selectedCase) return;
+
+    try {
+      await solicitarDiagnostico({ docenteId, casoId: selectedCase.id, observaciones });
+      await refreshCases(selectedCase.id);
+      toast.success("Solicitud de diagnóstico enviada");
+    } catch (error) {
+      console.error(error);
+      toast.error("No se pudo enviar la solicitud");
+    }
+  };
+
+  const handleCreatePlan = async (payload: { objetivo: string; acciones: string; responsable: string; fechaRevision: string }) => {
+    if (!selectedCase) return;
+
+    try {
+      await crearPlanIntervencion({
+        casoId: selectedCase.id,
+        objetivo: payload.objetivo,
+        acciones: payload.acciones,
+        responsable: payload.responsable,
+        fechaRevision: payload.fechaRevision || null,
+      });
+      await refreshCases(selectedCase.id);
+      toast.success("Plan de intervención guardado");
+    } catch (error) {
+      console.error(error);
+      toast.error("No se pudo guardar el plan");
+    }
+  };
+
+  const handleAddFollowUp = async (payload: { tipo: string; descripcion: string; evidenciaUrl: string }) => {
+    if (!selectedCase) return;
+
+    try {
+      const { error } = await supabase.from("seguimiento_orientacion" as any).insert({
+        caso_id: selectedCase.id,
+        tipo: payload.tipo,
+        descripcion: payload.descripcion,
+        evidencia_url: payload.evidenciaUrl || null,
+        created_by: user?.id ?? null,
+      });
+      if (error) throw error;
+      await refreshCases(selectedCase.id);
+      toast.success("Seguimiento registrado");
+    } catch (error) {
+      console.error(error);
+      toast.error("No se pudo registrar el seguimiento");
+    }
+  };
+
+  const handleQuickOpenCase = async () => {
+    const student = suggestions[0];
+    if (!student) {
+      toast.error("No hay alumnos sugeridos");
+      return;
+    }
+    await handleOpenStudentCase(student.rawId);
+  };
+
+  const handleDeriveSocialWork = async () => {
+    if (!selectedCase) return;
+    try {
+      await derivarTrabajoSocial(selectedCase.id);
+      await refreshCases(selectedCase.id);
+      toast.success("Caso derivado a Trabajo Social");
+    } catch (error) {
+      console.error(error);
+      toast.error("No se pudo derivar el caso");
+    }
+  };
+
+  const handleEscalateDirection = async () => {
+    if (!selectedCase) return;
+    try {
+      await escalarDireccion(selectedCase.id);
+      await refreshCases(selectedCase.id);
+      toast.success("Caso escalado a Dirección");
+    } catch (error) {
+      console.error(error);
+      toast.error("No se pudo escalar el caso");
+    }
+  };
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  const studentLabel = selectedCase
+    ? `${selectedCase.alumnoNombre} · ${selectedCase.grupo ?? "Sin grupo"}`
+    : "Selecciona un caso para ver el historial";
+
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      className="flex-1 p-6 lg:p-8 relative z-10 w-full max-w-7xl mx-auto h-full flex flex-col"
-    >
-      <div className="mb-6 flex flex-col md:flex-row md:items-end md:justify-between gap-4">
-        <div>
-          <p className="text-[10px] font-bold text-slate-700 uppercase tracking-widest">
-            Modulo padre
-          </p>
-          <p className="text-slate-200 text-sm font-semibold">
-            Atencion Integral del Estudiante
-          </p>
-          <h1 className="text-3xl font-bold text-white mb-2 tracking-wide">
-            Orientacion Educativa
-          </h1>
-          <p className="text-slate-600 text-sm">
-            Acompañamiento socioemocional, contencion y seguimiento del estudiante.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <NeoButton
-            icon="print"
-            onClick={handlePrepareBitacora}
-            className="px-4 py-3"
-          >
-            Generar bitácora institucional
-          </NeoButton>
-          <NeoButton
-            icon="add_chart"
-            onClick={() => setCurrentModule(AppModule.REPORTES_DOCENTES)}
-            className="px-4 py-3 text-sase-warning"
-          >
-            Solicitar actualización de seguimiento
-          </NeoButton>
-        </div>
-      </div>
+    <main className="min-h-screen overflow-y-auto bg-slate-950 px-4 py-4 text-white md:px-6 lg:px-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-4">
+        <OrientacionRoleHeader
+          activeCases={activeCases}
+          pendingRequests={pendingRequests}
+          criticalCases={criticalCases}
+          onNewCase={handleQuickOpenCase}
+          onPrint={handlePrint}
+        />
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 flex-1 min-h-0">
-        <GlassCard icon="psychology" title="Casos en intervencion activa" className="flex flex-col h-full">
-          <div className="flex-1 overflow-y-auto custom-scrollbar pr-2 mt-4 space-y-3">
-            <AnimatePresence>
-              {highRiskStudents.length === 0 ? (
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="p-10 text-center text-slate-700"
-                >
-                  Sin alertas de riesgo registradas en el sistema.
-                </motion.div>
-              ) : (
-                highRiskStudents.map((s, idx) => (
-                  <motion.div
-                    key={s.id}
-                    initial={{ opacity: 0, y: 10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: idx * 0.05 }}
-                    className="p-4 rounded-xl border border-slate-100 bg-white/[0.02] hover:bg-white/[0.05] transition-colors group"
-                  >
-                    <div className="flex justify-between items-start gap-4">
-                      <div>
-                        <h3 className="text-white font-medium text-sm">{s.name}</h3>
-                        <p className="text-slate-600 text-xs mt-1">
-                          {s.caseState === CaseState.INTERVENCION ? "Acompañamiento Intensivo" : "Patron de riesgo socioemocional detectado"}
-                        </p>
-                        <p className="text-slate-700 text-xs mt-1">
-                          {s.group} · {s.matricula}
-                        </p>
-                      </div>
-                      <span className={`px-3 py-1 rounded-full text-xs font-semibold border ${getStatusColors(s.caseState)} shadow-lg`}>
-                        {CaseLabels[s.caseState]}
-                      </span>
-                    </div>
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <NeoButton
-                        onClick={() => {
-                          setSelectedStudent(s);
-                          setShowAdvancedPanel(true);
-                        }}
-                        className="px-4 py-2"
-                      >
-                        Iniciar intervención
-                      </NeoButton>
-                      <NeoButton
-                        onClick={() => handleNotifyAcademicRisk(s.id, "patron detectado")}
-                        className="px-4 py-2"
-                      >
-                        Notificar al equipo académico
-                      </NeoButton>
-                    </div>
-                  </motion.div>
-                ))
-              )}
-            </AnimatePresence>
-          </div>
-        </GlassCard>
+        <OrientacionInsights
+          urgent={criticalCases}
+          openRequests={pendingRequests}
+          plans={history.plans.length}
+          followUps={history.followUps.length}
+        />
 
-        <GlassCard icon="family_restroom" title="Agenda de atencion" className="flex flex-col h-full">
-          <div className="flex-1 overflow-y-auto custom-scrollbar pr-2 mt-4">
-            <div className="p-8 rounded-xl border border-slate-100 bg-white/[0.02] text-center text-slate-700">
-              Sin citas programadas para el dia de hoy.
+        {loading ? (
+          <GlassCard className="border border-white/5 bg-slate-950/55">
+            <div className="p-6 text-center text-slate-400">Cargando casos de Orientación...</div>
+          </GlassCard>
+        ) : (
+          <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-4">
+              <OrientacionCaseInbox
+                cases={cases}
+                students={suggestions}
+                selectedCaseId={selectedCase?.id ?? null}
+                onSelectCase={(caseId) => setSelectedCaseId(caseId)}
+                onOpenStudentCase={handleOpenStudentCase}
+              />
+              <OrientacionCaseDetail
+                selectedCase={selectedCase}
+                requests={history.requests}
+                plans={history.plans}
+                followUps={history.followUps}
+                onRequestDiagnosis={() => {
+                  const nextDocente = docentes[0]?.id;
+                  if (!nextDocente || !selectedCase) return toast.error("No hay docente disponible");
+                  void handleRequestDiagnosis(nextDocente, `Solicitud institucional para ${selectedCase.alumnoNombre}.`);
+                }}
+                onDeriveSocialWork={handleDeriveSocialWork}
+                onEscalateDirection={handleEscalateDirection}
+              />
+              <StudentInstitutionalHistory
+                studentLabel={studentLabel}
+                summary={history.summary}
+                incidents={history.incidents}
+                citations={history.citations}
+                contacts={history.contacts}
+                interventions={history.interventions}
+                teacherReports={history.teacherReports}
+              />
+            </div>
+
+            <div className="space-y-4">
+              <TeacherDiagnosisRequests
+                requests={history.requests}
+                docentes={docentes}
+                onRequest={handleRequestDiagnosis}
+              />
+              <InterventionPlanEditor plans={history.plans} onCreatePlan={handleCreatePlan} />
+              <OrientacionFollowUpPanel followUps={history.followUps} onAddFollowUp={handleAddFollowUp} />
+              <OrientacionReportPreview selectedCase={selectedCase} history={history} plans={history.plans} followUps={history.followUps} />
             </div>
           </div>
-
-          <div className="mt-4 pt-4 border-t border-slate-200 grid grid-cols-1 gap-3">
-            <NeoButton
-              icon="add_alert"
-              onClick={() => setModalOpen("APPOINTMENT")}
-              className="w-full justify-center py-3"
-            >
-              Generar citatorio
-            </NeoButton>
-            <NeoButton
-              icon="history_edu"
-              onClick={() => setModalOpen("INTERVIEW")}
-              className="w-full justify-center py-3"
-            >
-              Registrar entrevista
-            </NeoButton>
-            {supportProtocol && (
-              <NeoButton
-                icon="menu_book"
-                onClick={() => setShowProtocol(true)}
-                className="w-full justify-center py-3 text-sase-danger"
-              >
-                Activar protocolo crítico
-              </NeoButton>
-            )}
-          </div>
-        </GlassCard>
+        )}
       </div>
-
-      {/* MODALS */}
-      {showProtocol && supportProtocol && (
-        <ProtocolDetailModal
-          protocol={supportProtocol}
-          onClose={() => setShowProtocol(false)}
-        />
-      )}
-
-      {selectedStudent && showAdvancedPanel && (
-        <StudentAdvancedPanel
-          student={selectedStudent}
-          onClose={() => setShowAdvancedPanel(false)}
-        />
-      )}
-
-      <GenericActionModal
-        isOpen={modalOpen === "APPOINTMENT"}
-        onClose={() => setModalOpen(null)}
-        title="Gestion de citatorios institucionales"
-        description="Gestion de reuniones con tutores legales"
-        fields={[
-          {
-            name: "student",
-            label: "Matricula del alumno",
-            type: "text",
-            required: true,
-          },
-          {
-            name: "reason",
-            label: "Motivo del citatorio (descripcion breve)",
-            type: "select",
-            options: [
-              "ALERTA_CONDUCTA",
-              "BAJO_DESEMPEÑO",
-              "FALLA_SISTEMÁTICA",
-              "SEGUIMIENTO_PSIC",
-            ],
-            required: true,
-          },
-          {
-            name: "date",
-            label: "Fecha y hora",
-            type: "date",
-            required: true,
-          },
-        ]}
-        onSubmit={handleSaveAppointment}
-      />
-
-      <GenericActionModal
-        isOpen={modalOpen === "INTERVIEW"}
-        onClose={() => setModalOpen(null)}
-        title="Registro de entrevistas institucionales"
-        description="Registro de intervencion directa"
-        fields={[
-          {
-            name: "student",
-            label: "Matricula del alumno",
-            type: "text",
-            required: true,
-          },
-          {
-            name: "reason",
-            label: "Motivo de atencion",
-            type: "text",
-            required: true,
-          },
-          {
-            name: "notes",
-            label: "Notas de intervencion",
-            type: "textarea",
-            required: true,
-          },
-          {
-            name: "result",
-            label: "Resultado de la intervencion",
-            type: "select",
-            options: [
-              "PROTOCOLO_ACTIVADO",
-              "EN_OBSERVACIÓN",
-              "CASO_CERRADO",
-              "CANALIZACIÓN_EXTERNA",
-            ],
-            required: true,
-          },
-        ]}
-        onSubmit={handleSaveInterview}
-      />
-
-      <PrintPreviewModal
-        isOpen={showPrintPreview}
-        onClose={() => setShowPrintPreview(false)}
-        title="BITÁCORA DE INTERVENCIÓN PSICOPEDAGÓGICA"
-        initialHtml={previewContent}
-      />
-    </motion.div>
+    </main>
   );
 };

--- a/src/components/orientacion/InterventionPlanEditor.tsx
+++ b/src/components/orientacion/InterventionPlanEditor.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { GlassCard } from "../ui/GlassCard";
+import { NeoButton } from "../ui/NeoButton";
+import type { OrientacionPlan } from "./orientacionTypes";
+
+interface Props {
+  plans: OrientacionPlan[];
+  onCreatePlan: (payload: { objetivo: string; acciones: string; responsable: string; fechaRevision: string }) => void;
+}
+
+export function InterventionPlanEditor({ plans, onCreatePlan }: Props) {
+  const [objetivo, setObjetivo] = useState("");
+  const [acciones, setAcciones] = useState("");
+  const [responsable, setResponsable] = useState("");
+  const [fechaRevision, setFechaRevision] = useState("");
+
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <h2 className="text-lg font-bold text-white">Plan de intervención</h2>
+      <p className="mt-1 text-sm text-slate-400">Define objetivos, acciones y revisión para el caso.</p>
+
+      <div className="mt-4 grid gap-3">
+        <input className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={objetivo} onChange={(e) => setObjetivo(e.target.value)} placeholder="Objetivo institucional" />
+        <textarea className="min-h-24 rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={acciones} onChange={(e) => setAcciones(e.target.value)} placeholder="Acciones, responsables, frecuencia, acuerdos." />
+        <input className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={responsable} onChange={(e) => setResponsable(e.target.value)} placeholder="Responsable principal" />
+        <input type="date" className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={fechaRevision} onChange={(e) => setFechaRevision(e.target.value)} />
+        <NeoButton onClick={() => onCreatePlan({ objetivo, acciones, responsable, fechaRevision })} className="w-full bg-violet-500/20 text-white">
+          Guardar plan
+        </NeoButton>
+      </div>
+
+      <div className="mt-5 space-y-2">
+        {plans.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-white/10 p-3 text-sm text-slate-400">Sin planes registrados.</div>
+        ) : (
+          plans.slice(0, 3).map((plan) => (
+            <div key={plan.id} className="rounded-xl border border-white/5 bg-black/20 p-3">
+              <div className="text-sm font-semibold text-white">{plan.objetivo}</div>
+              <div className="mt-1 text-sm text-slate-300">{plan.acciones}</div>
+              <div className="mt-2 text-[11px] text-slate-500">Responsable: {plan.responsable}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/orientacion/OrientacionCaseDetail.tsx
+++ b/src/components/orientacion/OrientacionCaseDetail.tsx
@@ -1,0 +1,71 @@
+import { GlassCard } from "../ui/GlassCard";
+import { NeoButton } from "../ui/NeoButton";
+import { ORIENTACION_CASE_LABELS, ORIENTACION_PRIORITY_LABELS, ORIENTACION_PRIORITY_STYLES, ORIENTACION_STATE_STYLES, type OrientacionCaseSummary, type OrientacionDiagnosisRequest, type OrientacionPlan, type OrientacionFollowUp } from "./orientacionTypes";
+
+interface Props {
+  selectedCase: OrientacionCaseSummary | null;
+  requests: OrientacionDiagnosisRequest[];
+  plans: OrientacionPlan[];
+  followUps: OrientacionFollowUp[];
+  onRequestDiagnosis: () => void;
+  onDeriveSocialWork: () => void;
+  onEscalateDirection: () => void;
+}
+
+export function OrientacionCaseDetail({ selectedCase, requests, plans, followUps, onRequestDiagnosis, onDeriveSocialWork, onEscalateDirection }: Props) {
+  if (!selectedCase) {
+    return (
+      <GlassCard className="border border-white/5 bg-slate-950/55">
+        <div className="rounded-2xl border border-dashed border-white/10 p-6 text-center text-slate-400">Selecciona un caso para ver el detalle institucional.</div>
+      </GlassCard>
+    );
+  }
+
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold text-white">{selectedCase.alumnoNombre}</h2>
+            <div className="mt-1 text-sm text-slate-400">{selectedCase.grupo ?? "Sin grupo"} · {selectedCase.matricula ?? "Sin matrícula"}</div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge text={ORIENTACION_CASE_LABELS[selectedCase.estado]} className={ORIENTACION_STATE_STYLES[selectedCase.estado]} />
+            <Badge text={ORIENTACION_PRIORITY_LABELS[selectedCase.prioridad]} className={ORIENTACION_PRIORITY_STYLES[selectedCase.prioridad]} />
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/5 bg-black/20 p-4 text-sm text-slate-300">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-slate-400">Motivo</div>
+          <div className="mt-1">{selectedCase.motivo}</div>
+          {selectedCase.resumen ? <div className="mt-3 text-slate-200">{selectedCase.resumen}</div> : null}
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-3">
+          <NeoButton onClick={onRequestDiagnosis} className="bg-violet-500/20 text-white">Pedir diagnóstico</NeoButton>
+          <NeoButton onClick={onDeriveSocialWork} className="bg-amber-500/15 text-amber-100">Derivar</NeoButton>
+          <NeoButton onClick={onEscalateDirection} className="bg-rose-500/15 text-rose-100">Escalar</NeoButton>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-3">
+          <MetaCard title="Diagnósticos" value={requests.length} />
+          <MetaCard title="Planes" value={plans.length} />
+          <MetaCard title="Seguimientos" value={followUps.length} />
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+function Badge({ text, className }: { text: string; className: string }) {
+  return <span className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.18em] ${className}`}>{text}</span>;
+}
+
+function MetaCard({ title, value }: { title: string; value: number }) {
+  return (
+    <div className="rounded-2xl border border-white/5 bg-black/20 p-3">
+      <div className="text-[10px] uppercase tracking-[0.18em] text-slate-400">{title}</div>
+      <div className="mt-1 text-2xl font-black text-white">{value}</div>
+    </div>
+  );
+}

--- a/src/components/orientacion/OrientacionCaseInbox.tsx
+++ b/src/components/orientacion/OrientacionCaseInbox.tsx
@@ -1,0 +1,87 @@
+import { GlassCard } from "../ui/GlassCard";
+import { NeoButton } from "../ui/NeoButton";
+import {
+  ORIENTACION_CASE_LABELS,
+  ORIENTACION_PRIORITY_LABELS,
+  ORIENTACION_PRIORITY_STYLES,
+  ORIENTACION_STATE_STYLES,
+  type OrientacionCaseSummary,
+  type OrientacionStudentSummary,
+} from "./orientacionTypes";
+
+interface Props {
+  cases: OrientacionCaseSummary[];
+  students: OrientacionStudentSummary[];
+  selectedCaseId: string | null;
+  onSelectCase: (caseId: string) => void;
+  onOpenStudentCase: (studentId: string) => void;
+}
+
+export function OrientacionCaseInbox({ cases, students, selectedCaseId, onSelectCase, onOpenStudentCase }: Props) {
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-white">Bandeja de casos</h2>
+          <p className="text-sm text-slate-400">Casos persistidos y sugerencias para abrir nuevos expedientes de Orientación.</p>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-3">
+        {cases.length === 0 ? (
+          <EmptyState title="Sin casos persistidos" description="Aún no hay casos abiertos; usa la bandeja sugerida para crear el primero." />
+        ) : (
+          cases.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => onSelectCase(item.id)}
+              className={`w-full rounded-2xl border p-4 text-left transition ${selectedCaseId === item.id ? "border-violet-400/40 bg-violet-500/10" : "border-white/5 bg-white/[0.03] hover:bg-white/[0.06]"}`}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="text-base font-semibold text-white">{item.alumnoNombre}</div>
+                  <div className="text-xs text-slate-400">{item.grupo ?? "Sin grupo"} · {item.matricula ?? "Sin matrícula"}</div>
+                  <div className="mt-2 text-sm text-slate-300">{item.motivo}</div>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                  <Badge text={ORIENTACION_CASE_LABELS[item.estado]} className={ORIENTACION_STATE_STYLES[item.estado]} />
+                  <Badge text={ORIENTACION_PRIORITY_LABELS[item.prioridad]} className={ORIENTACION_PRIORITY_STYLES[item.prioridad]} />
+                </div>
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+
+      <div className="mt-5 border-t border-white/5 pt-4">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.18em] text-slate-400">Sugeridos para abrir caso</h3>
+        <div className="mt-3 grid gap-2">
+          {students.slice(0, 5).map((student) => (
+            <div key={student.id} className="flex items-center justify-between gap-3 rounded-2xl border border-white/5 bg-black/20 p-3">
+              <div>
+                <div className="text-sm font-semibold text-white">{student.nombre}</div>
+                <div className="text-xs text-slate-400">{student.grupo ?? "Sin grupo"} · {student.matricula ?? "Sin matrícula"}</div>
+              </div>
+              <NeoButton onClick={() => onOpenStudentCase(student.id)} className="px-3 py-2 text-xs">
+                Abrir
+              </NeoButton>
+            </div>
+          ))}
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+function Badge({ text, className }: { text: string; className: string }) {
+  return <span className={`inline-flex rounded-full border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.18em] ${className}`}>{text}</span>;
+}
+
+function EmptyState({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-white/10 bg-black/20 p-5 text-center">
+      <div className="font-semibold text-white">{title}</div>
+      <div className="mt-1 text-sm text-slate-400">{description}</div>
+    </div>
+  );
+}

--- a/src/components/orientacion/OrientacionFollowUpPanel.tsx
+++ b/src/components/orientacion/OrientacionFollowUpPanel.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { GlassCard } from "../ui/GlassCard";
+import { NeoButton } from "../ui/NeoButton";
+import type { OrientacionFollowUp } from "./orientacionTypes";
+
+interface Props {
+  followUps: OrientacionFollowUp[];
+  onAddFollowUp: (payload: { tipo: string; descripcion: string; evidenciaUrl: string }) => void;
+}
+
+export function OrientacionFollowUpPanel({ followUps, onAddFollowUp }: Props) {
+  const [tipo, setTipo] = useState("nota");
+  const [descripcion, setDescripcion] = useState("");
+  const [evidenciaUrl, setEvidenciaUrl] = useState("");
+
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <h2 className="text-lg font-bold text-white">Seguimiento y evidencia</h2>
+      <div className="mt-4 grid gap-3">
+        <select className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={tipo} onChange={(e) => setTipo(e.target.value)}>
+          <option value="nota">Nota</option>
+          <option value="entrevista">Entrevista</option>
+          <option value="diagnostico">Diagnóstico</option>
+          <option value="plan">Plan</option>
+          <option value="derivacion">Derivación</option>
+          <option value="escalamiento">Escalamiento</option>
+          <option value="evidencia">Evidencia</option>
+        </select>
+        <textarea className="min-h-24 rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={descripcion} onChange={(e) => setDescripcion(e.target.value)} placeholder="Describe el seguimiento, el acuerdo o la evidencia." />
+        <input className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={evidenciaUrl} onChange={(e) => setEvidenciaUrl(e.target.value)} placeholder="URL de evidencia (opcional)" />
+        <NeoButton onClick={() => onAddFollowUp({ tipo, descripcion, evidenciaUrl })} className="w-full bg-violet-500/20 text-white">
+          Registrar seguimiento
+        </NeoButton>
+      </div>
+
+      <div className="mt-5 space-y-2">
+        {followUps.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-white/10 p-3 text-sm text-slate-400">Sin seguimientos recientes.</div>
+        ) : (
+          followUps.slice(0, 5).map((item) => (
+            <div key={item.id} className="rounded-xl border border-white/5 bg-black/20 p-3">
+              <div className="text-xs uppercase tracking-[0.16em] text-violet-200">{item.tipo}</div>
+              <div className="mt-1 text-sm text-slate-200">{item.descripcion}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/orientacion/OrientacionInsights.tsx
+++ b/src/components/orientacion/OrientacionInsights.tsx
@@ -1,0 +1,28 @@
+import { GlassCard } from "../ui/GlassCard";
+
+interface Props {
+  urgent: number;
+  openRequests: number;
+  plans: number;
+  followUps: number;
+}
+
+export function OrientacionInsights({ urgent, openRequests, plans, followUps }: Props) {
+  const items = [
+    { label: "Urgentes", value: urgent },
+    { label: "Pendientes", value: openRequests },
+    { label: "Planes", value: plans },
+    { label: "Seguimientos", value: followUps },
+  ];
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {items.map((item) => (
+        <GlassCard key={item.label} className="border border-white/5 bg-slate-950/60">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-slate-400">{item.label}</div>
+          <div className="mt-2 text-3xl font-black text-white">{item.value}</div>
+        </GlassCard>
+      ))}
+    </div>
+  );
+}

--- a/src/components/orientacion/OrientacionReportPreview.tsx
+++ b/src/components/orientacion/OrientacionReportPreview.tsx
@@ -1,0 +1,45 @@
+import { GlassCard } from "../ui/GlassCard";
+import type { OrientacionCaseSummary, OrientacionFollowUp, OrientacionHistoryItem, OrientacionPlan } from "./orientacionTypes";
+
+interface Props {
+  selectedCase: OrientacionCaseSummary | null;
+  history: {
+    incidents: OrientacionHistoryItem[];
+    citations: OrientacionHistoryItem[];
+    contacts: OrientacionHistoryItem[];
+    interventions: OrientacionHistoryItem[];
+  };
+  plans: OrientacionPlan[];
+  followUps: OrientacionFollowUp[];
+}
+
+export function OrientacionReportPreview({ selectedCase, history, plans, followUps }: Props) {
+  if (!selectedCase) return null;
+
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <h2 className="text-lg font-bold text-white">Reporte imprimible</h2>
+      <p className="mt-1 text-sm text-slate-400">Resumen institucional listo para imprimir o pegar en oficio.</p>
+
+      <div className="mt-4 rounded-2xl border border-white/5 bg-black/20 p-4 text-sm text-slate-300">
+        <div className="font-semibold text-white">{selectedCase.alumnoNombre}</div>
+        <div className="mt-1 text-slate-400">{selectedCase.grupo ?? "Sin grupo"} · {selectedCase.matricula ?? "Sin matrícula"}</div>
+        <div className="mt-3">{selectedCase.motivo}</div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-3">
+          <Mini label="Incidencias" value={history.incidents.length} />
+          <Mini label="Planes" value={plans.length} />
+          <Mini label="Seguimientos" value={followUps.length} />
+        </div>
+      </div>
+    </GlassCard>
+  );
+}
+
+function Mini({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-2xl border border-white/5 bg-white/[0.03] p-3">
+      <div className="text-[10px] uppercase tracking-[0.18em] text-slate-400">{label}</div>
+      <div className="mt-1 text-xl font-black text-white">{value}</div>
+    </div>
+  );
+}

--- a/src/components/orientacion/OrientacionRoleHeader.tsx
+++ b/src/components/orientacion/OrientacionRoleHeader.tsx
@@ -1,0 +1,52 @@
+import { GlassCard } from "../ui/GlassCard";
+import { NeoButton } from "../ui/NeoButton";
+
+interface Props {
+  activeCases: number;
+  pendingRequests: number;
+  criticalCases: number;
+  onNewCase: () => void;
+  onPrint: () => void;
+}
+
+export function OrientacionRoleHeader({ activeCases, pendingRequests, criticalCases, onNewCase, onPrint }: Props) {
+  return (
+    <GlassCard className="border border-violet-400/10 bg-violet-950/40">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="inline-flex items-center rounded-full border border-violet-400/20 bg-violet-500/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.2em] text-violet-200">
+            Orientación
+          </div>
+          <h1 className="mt-3 text-3xl font-black tracking-tight text-white md:text-4xl">
+            Casos, diagnósticos y evidencia institucional
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm text-slate-300">
+            Bandeja persistente para abrir casos, pedir diagnóstico docente, definir plan y dejar trazabilidad para Dirección, Subdirección y Trabajo Social.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <NeoButton onClick={onPrint} className="border-violet-400/20 bg-violet-500/10 text-violet-100">
+            Reporte
+          </NeoButton>
+          <NeoButton onClick={onNewCase} className="border-violet-400/20 bg-violet-500/20 text-white">
+            Abrir caso
+          </NeoButton>
+        </div>
+      </div>
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <Stat label="Casos activos" value={activeCases} />
+        <Stat label="Solicitudes pendientes" value={pendingRequests} />
+        <Stat label="Casos críticos" value={criticalCases} />
+      </div>
+    </GlassCard>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-2xl border border-white/5 bg-black/20 px-4 py-3">
+      <div className="text-[10px] uppercase tracking-[0.18em] text-slate-400">{label}</div>
+      <div className="mt-1 text-2xl font-black text-white">{value}</div>
+    </div>
+  );
+}

--- a/src/components/orientacion/StudentInstitutionalHistory.tsx
+++ b/src/components/orientacion/StudentInstitutionalHistory.tsx
@@ -1,0 +1,64 @@
+import { GlassCard } from "../ui/GlassCard";
+import type { OrientacionHistoryItem } from "./orientacionTypes";
+
+interface Props {
+  studentLabel: string;
+  summary: any | null;
+  incidents: OrientacionHistoryItem[];
+  citations: OrientacionHistoryItem[];
+  contacts: OrientacionHistoryItem[];
+  interventions: OrientacionHistoryItem[];
+  teacherReports: OrientacionHistoryItem[];
+}
+
+export function StudentInstitutionalHistory({ studentLabel, summary, incidents, citations, contacts, interventions, teacherReports }: Props) {
+  const counts = [
+    { label: "Incidencias", value: summary?.total_incidencias ?? incidents.length },
+    { label: "Reportes docentes", value: teacherReports.length },
+    { label: "Citas", value: summary?.total_justificantes ?? citations.length },
+    { label: "Contactos", value: contacts.length },
+    { label: "Intervenciones", value: interventions.length },
+  ];
+
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <h2 className="text-lg font-bold text-white">Historial institucional</h2>
+      <p className="mt-1 text-sm text-slate-400">{studentLabel}</p>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+        {counts.map((item) => (
+          <div key={item.label} className="rounded-2xl border border-white/5 bg-black/20 p-3">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-slate-400">{item.label}</div>
+            <div className="mt-1 text-2xl font-black text-white">{item.value}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        <HistoryColumn title="Incidencias" items={incidents} />
+        <HistoryColumn title="Reportes y contactos" items={[...teacherReports, ...citations, ...contacts, ...interventions]} />
+      </div>
+    </GlassCard>
+  );
+}
+
+function HistoryColumn({ title, items }: { title: string; items: OrientacionHistoryItem[] }) {
+  return (
+    <div className="rounded-2xl border border-white/5 bg-black/15 p-3">
+      <div className="text-sm font-semibold text-white">{title}</div>
+      <div className="mt-3 space-y-2">
+        {items.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-white/10 p-3 text-sm text-slate-400">Sin registros recientes.</div>
+        ) : (
+          items.slice(0, 4).map((item) => (
+            <div key={item.id} className="rounded-xl border border-white/5 bg-white/[0.03] p-3">
+              <div className="text-xs uppercase tracking-[0.16em] text-violet-200">{item.titulo}</div>
+              <div className="mt-1 text-sm text-slate-200">{item.detalle}</div>
+              <div className="mt-2 text-[11px] text-slate-500">{item.fuente}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/orientacion/TeacherDiagnosisRequests.tsx
+++ b/src/components/orientacion/TeacherDiagnosisRequests.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { GlassCard } from "../ui/GlassCard";
+import { NeoButton } from "../ui/NeoButton";
+import type { OrientacionDiagnosisRequest, OrientacionDocenteOption } from "./orientacionTypes";
+
+interface Props {
+  requests: OrientacionDiagnosisRequest[];
+  docentes: OrientacionDocenteOption[];
+  onRequest: (docenteId: string, observaciones: string) => void;
+}
+
+export function TeacherDiagnosisRequests({ requests, docentes, onRequest }: Props) {
+  const [docenteId, setDocenteId] = useState(docentes[0]?.id ?? "");
+  const [observaciones, setObservaciones] = useState("");
+
+  useEffect(() => {
+    if (!docenteId && docentes[0]?.id) {
+      setDocenteId(docentes[0].id);
+    }
+  }, [docenteId, docentes]);
+
+  return (
+    <GlassCard className="border border-white/5 bg-slate-950/55">
+      <h2 className="text-lg font-bold text-white">Solicitudes de diagnóstico</h2>
+      <p className="mt-1 text-sm text-slate-400">Envía una solicitud solo a docentes asignados.</p>
+
+      <div className="mt-4 grid gap-3">
+        <label className="grid gap-1 text-sm text-slate-300">
+          Docente
+          <select className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={docenteId} onChange={(e) => setDocenteId(e.target.value)}>
+            <option value="">Selecciona un docente</option>
+            {docentes.map((docente) => (
+              <option key={docente.id} value={docente.id}>{docente.nombreCompleto}</option>
+            ))}
+          </select>
+        </label>
+        <label className="grid gap-1 text-sm text-slate-300">
+          Observaciones
+          <textarea className="min-h-24 rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-white" value={observaciones} onChange={(e) => setObservaciones(e.target.value)} placeholder="Contexto del caso, puntos a evaluar, fecha límite, etc." />
+        </label>
+        <NeoButton onClick={() => onRequest(docenteId, observaciones)} className="w-full bg-violet-500/20 text-white">
+          Enviar solicitud
+        </NeoButton>
+      </div>
+
+      <div className="mt-5 space-y-2">
+        {requests.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-white/10 p-3 text-sm text-slate-400">Sin solicitudes de diagnóstico aún.</div>
+        ) : (
+          requests.slice(0, 4).map((request) => (
+            <div key={request.id} className="rounded-xl border border-white/5 bg-black/20 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-semibold text-white">Solicitud {request.estado}</div>
+                <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-slate-300">{request.fechaSolicitud}</span>
+              </div>
+              <div className="mt-2 text-sm text-slate-300">{request.observaciones ?? "Sin observaciones"}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </GlassCard>
+  );
+}

--- a/src/components/orientacion/orientacionApi.ts
+++ b/src/components/orientacion/orientacionApi.ts
@@ -1,0 +1,278 @@
+import { supabase } from "../../supabase/client";
+import type {
+  OrientacionCasePrioridad,
+  OrientacionCaseSummary,
+  OrientacionDiagnosisRequest,
+  OrientacionDocenteOption,
+  OrientacionFollowUp,
+  OrientacionHistoryItem,
+  OrientacionPlan,
+  OrientacionStudentSummary,
+} from "./orientacionTypes";
+
+const selectStudentFields = "id, nombre_completo, grupo, matricula, puntaje_riesgo, estado_semaforo";
+
+export async function loadOrientacionCasos(): Promise<OrientacionCaseSummary[]> {
+  const { data: casos, error } = await supabase
+    .from("orientacion_casos")
+    .select("id, alumno_id, creado_por, responsable_id, estado, prioridad, motivo, resumen, fecha_apertura, fecha_actualizacion")
+    .order("fecha_actualizacion", { ascending: false });
+
+  if (error) throw error;
+
+  const casosRows = (casos ?? []) as any[];
+  const alumnoIds = Array.from(new Set(casosRows.map((item) => item.alumno_id)));
+  const { data: alumnos } = alumnoIds.length
+    ? await supabase
+        .from("alumnos" as any)
+        .select(selectStudentFields)
+        .in("id", alumnoIds)
+    : { data: [] as any[] };
+
+  const alumnosById = new Map<string, any>(((alumnos ?? []) as any[]).map((item) => [item.id, item]));
+
+  return casosRows.map((caso) => {
+    const alumno = alumnosById.get(caso.alumno_id);
+    return {
+      id: caso.id,
+      alumnoId: caso.alumno_id,
+      alumnoNombre: alumno?.nombre_completo ?? "Alumno no disponible",
+      grupo: alumno?.grupo ?? null,
+      matricula: alumno?.matricula ?? null,
+      estado: caso.estado as OrientacionCaseSummary["estado"],
+      prioridad: caso.prioridad as OrientacionCasePrioridad,
+      motivo: caso.motivo,
+      resumen: caso.resumen,
+      fechaApertura: caso.fecha_apertura,
+      fechaActualizacion: caso.fecha_actualizacion,
+      responsableId: caso.responsable_id,
+    };
+  });
+}
+
+export async function loadDocentes(): Promise<OrientacionDocenteOption[]> {
+  const { data, error } = await supabase
+    .from("perfiles_usuario" as any)
+    .select("id, nombre_completo, rol")
+    .in("rol", ["docente", "docente_tutor"])
+    .order("nombre_completo", { ascending: true });
+
+  if (error) throw error;
+
+  return ((data ?? []) as any[]).map((item) => ({
+    id: item.id,
+    nombreCompleto: item.nombre_completo ?? "Docente",
+    rol: item.rol ?? "docente",
+  }));
+}
+
+export async function loadStudentHistory(studentId: string, caseId?: string): Promise<{
+  summary: any | null;
+  incidents: OrientacionHistoryItem[];
+  citations: OrientacionHistoryItem[];
+  contacts: OrientacionHistoryItem[];
+  interventions: OrientacionHistoryItem[];
+  teacherReports: OrientacionHistoryItem[];
+  plans: OrientacionPlan[];
+  requests: OrientacionDiagnosisRequest[];
+  followUps: OrientacionFollowUp[];
+}> {
+  const groupResult = await supabase.from("alumnos" as any).select("grupo").eq("id", studentId).maybeSingle();
+  const group = (groupResult.data as any)?.grupo ?? null;
+
+  const [summaryResult, incidentsResult, citationsResult, contactsResult, interventionsResult, teacherReportsResult, plansResult, requestsResult, followUpsResult] = await Promise.all([
+    supabase.from("expediente_integral_alumno" as any).select("*").eq("alumno_id", studentId).maybeSingle(),
+    supabase.from("incidencias" as any).select("id, fecha, tipo, descripcion, estado").eq("alumno_id", studentId).order("fecha", { ascending: false }).limit(5),
+    supabase.from("citas_padres" as any).select("id, created_at, fecha_cita, motivo, estado").eq("alumno_id", studentId).order("fecha_cita", { ascending: false }).limit(5),
+    supabase.from("contacts_log" as any).select("id, created_at, method, notes, outcome").eq("student_id", studentId).order("created_at", { ascending: false }).limit(5),
+    supabase.from("interventions_log" as any).select("id, created_at, reason, notes, result").eq("student_id", studentId).order("created_at", { ascending: false }).limit(5),
+    group
+      ? supabase.from("respuestas_docentes" as any).select("id, fecha, docente, comentarios, impacto, periodo").eq("grupo", group).order("fecha", { ascending: false }).limit(5)
+      : supabase.from("respuestas_docentes" as any).select("id, fecha, docente, comentarios, impacto, periodo").eq("grupo", "0000"),
+    caseId
+      ? supabase.from("planes_intervencion" as any).select("*").eq("caso_id", caseId).order("fecha_inicio", { ascending: false })
+      : supabase.from("planes_intervencion" as any).select("*").eq("caso_id", "00000000-0000-0000-0000-000000000000"),
+    caseId
+      ? supabase.from("solicitudes_diagnostico" as any).select("*").eq("caso_id", caseId).order("fecha_solicitud", { ascending: false })
+      : supabase.from("solicitudes_diagnostico" as any).select("*").eq("caso_id", "00000000-0000-0000-0000-000000000000"),
+    caseId
+      ? supabase.from("seguimiento_orientacion" as any).select("*").eq("caso_id", caseId).order("created_at", { ascending: false }).limit(20)
+      : supabase.from("seguimiento_orientacion" as any).select("*").eq("caso_id", "00000000-0000-0000-0000-000000000000"),
+  ]);
+
+  if (incidentsResult.error) throw incidentsResult.error;
+  if (citationsResult.error) throw citationsResult.error;
+  if (contactsResult.error) throw contactsResult.error;
+  if (interventionsResult.error) throw interventionsResult.error;
+  if (teacherReportsResult.error) throw teacherReportsResult.error;
+  if (plansResult.error) throw plansResult.error;
+  if (requestsResult.error) throw requestsResult.error;
+  if (followUpsResult.error) throw followUpsResult.error;
+  if (summaryResult.error) throw summaryResult.error;
+
+  const incidentsRows = (incidentsResult.data ?? []) as any[];
+  const citationsRows = (citationsResult.data ?? []) as any[];
+  const contactsRows = (contactsResult.data ?? []) as any[];
+  const interventionsRows = (interventionsResult.data ?? []) as any[];
+  const teacherReportRows = (teacherReportsResult.data ?? []) as any[];
+  const plansRows = (plansResult.data ?? []) as any[];
+  const requestsRows = (requestsResult.data ?? []) as any[];
+  const followUpRows = (followUpsResult.data ?? []) as any[];
+
+  return {
+    summary: summaryResult.data ?? null,
+    incidents: incidentsRows.map((item) => ({
+      id: item.id,
+      fecha: item.fecha ?? item.created_at ?? new Date().toISOString(),
+      titulo: item.tipo ?? "Incidencia",
+      detalle: item.descripcion ?? "Sin descripción",
+      fuente: `Estado: ${item.estado ?? "Nuevo"}`,
+    })),
+    citations: citationsRows.map((item) => ({
+      id: item.id,
+      fecha: item.fecha_cita ?? item.created_at ?? new Date().toISOString(),
+      titulo: item.motivo ?? "Citatorio",
+      detalle: `Estado: ${item.estado ?? "PENDIENTE"}`,
+      fuente: "Citas a familias",
+    })),
+    contacts: contactsRows.map((item) => ({
+      id: item.id,
+      fecha: item.created_at ?? new Date().toISOString(),
+      titulo: item.method ?? "Contacto",
+      detalle: item.notes ?? item.outcome ?? "Sin nota",
+      fuente: "Bitácora de contactos",
+    })),
+    interventions: interventionsRows.map((item) => ({
+      id: item.id,
+      fecha: item.created_at ?? new Date().toISOString(),
+      titulo: item.reason ?? "Intervención",
+      detalle: item.notes ?? item.result ?? "Sin resultado",
+      fuente: "Bitácora institucional",
+    })),
+    teacherReports: teacherReportRows.map((item) => ({
+      id: item.id,
+      fecha: item.fecha ?? new Date().toISOString(),
+      titulo: item.docente ?? "Reporte docente",
+      detalle: item.comentarios ?? `Impacto: ${item.impacto ?? "Sin dato"}`,
+      fuente: item.periodo ?? "Reportes docentes",
+    })),
+    plans: plansRows.map((item) => ({
+      id: item.id,
+      casoId: item.caso_id,
+      objetivo: item.objetivo,
+      acciones: item.acciones,
+      responsable: item.responsable,
+      fechaInicio: item.fecha_inicio,
+      fechaRevision: item.fecha_revision,
+      estado: item.estado,
+    })),
+    requests: requestsRows.map((item) => ({
+      id: item.id,
+      casoId: item.caso_id,
+      alumnoId: item.alumno_id,
+      docenteId: item.docente_id,
+      estado: item.estado,
+      fechaSolicitud: item.fecha_solicitud,
+      fechaRespuesta: item.fecha_respuesta,
+      observaciones: item.observaciones,
+    })),
+    followUps: followUpRows.map((item) => ({
+      id: item.id,
+      casoId: item.caso_id,
+      tipo: item.tipo,
+      descripcion: item.descripcion,
+      evidenciaUrl: item.evidencia_url,
+      createdBy: item.created_by,
+      createdAt: item.created_at,
+    })),
+  };
+}
+
+export async function abrirCasoOrientacion(params: {
+  alumnoId: string;
+  motivo: string;
+  resumen?: string | null;
+  prioridad?: OrientacionCasePrioridad;
+  responsableId?: string | null;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc("abrir_caso_orientacion", {
+    p_alumno_id: params.alumnoId,
+    p_motivo: params.motivo,
+    p_resumen: params.resumen ?? null,
+    p_prioridad: params.prioridad ?? "media",
+    p_responsable_id: params.responsableId ?? null,
+  });
+
+  if (error) throw error;
+  return data;
+}
+
+export async function solicitarDiagnostico(params: {
+  docenteId: string;
+  casoId: string;
+  observaciones?: string | null;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc("solicitar_diagnostico", {
+    p_docente_id: params.docenteId,
+    p_caso_id: params.casoId,
+    p_observaciones: params.observaciones ?? null,
+  });
+  if (error) throw error;
+  return data;
+}
+
+export async function registrarDiagnostico(params: {
+  solicitudId: string;
+  conducta?: string;
+  aprovechamiento?: string;
+  asistencia?: string;
+  observaciones?: string;
+  recomendaciones?: string;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc("registrar_diagnostico", {
+    p_solicitud_id: params.solicitudId,
+    p_conducta: params.conducta ?? null,
+    p_aprovechamiento: params.aprovechamiento ?? null,
+    p_asistencia: params.asistencia ?? null,
+    p_observaciones: params.observaciones ?? null,
+    p_recomendaciones: params.recomendaciones ?? null,
+  });
+  if (error) throw error;
+  return data;
+}
+
+export async function crearPlanIntervencion(params: {
+  casoId: string;
+  objetivo: string;
+  acciones: string;
+  responsable: string;
+  fechaInicio?: string;
+  fechaRevision?: string | null;
+  estado?: string;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc("crear_plan_intervencion", {
+    p_caso_id: params.casoId,
+    p_objetivo: params.objetivo,
+    p_acciones: params.acciones,
+    p_responsable: params.responsable,
+    p_fecha_inicio: params.fechaInicio ?? undefined,
+    p_fecha_revision: params.fechaRevision ?? null,
+    p_estado: params.estado ?? "activo",
+  });
+  if (error) throw error;
+  return data;
+}
+
+export async function derivarTrabajoSocial(casoId: string): Promise<void> {
+  const { error } = await supabase.rpc("derivar_trabajo_social", {
+    p_caso_id: casoId,
+  });
+  if (error) throw error;
+}
+
+export async function escalarDireccion(casoId: string): Promise<void> {
+  const { error } = await supabase.rpc("escalar_direccion", {
+    p_caso_id: casoId,
+  });
+  if (error) throw error;
+}

--- a/src/components/orientacion/orientacionTypes.ts
+++ b/src/components/orientacion/orientacionTypes.ts
@@ -1,0 +1,116 @@
+export type OrientacionCaseEstado =
+  | "recibido"
+  | "en_analisis"
+  | "diagnostico_solicitado"
+  | "plan_definido"
+  | "derivado_trabajo_social"
+  | "escalado_direccion"
+  | "cerrado";
+
+export type OrientacionCasePrioridad = "baja" | "media" | "alta" | "critica";
+
+export type OrientacionRequestEstado = "pendiente" | "respondido" | "vencido";
+
+export interface OrientacionStudentSummary {
+  id: string;
+  nombre: string;
+  grupo: string | null;
+  matricula: string | null;
+  puntajeRiesgo: number | null;
+  estadoSemaforo: string | null;
+}
+
+export interface OrientacionCaseSummary {
+  id: string;
+  alumnoId: string;
+  alumnoNombre: string;
+  grupo: string | null;
+  matricula: string | null;
+  estado: OrientacionCaseEstado;
+  prioridad: OrientacionCasePrioridad;
+  motivo: string;
+  resumen: string | null;
+  fechaApertura: string;
+  fechaActualizacion: string;
+  responsableId: string | null;
+}
+
+export interface OrientacionDocenteOption {
+  id: string;
+  nombreCompleto: string;
+  rol: string;
+}
+
+export interface OrientacionDiagnosisRequest {
+  id: string;
+  casoId: string;
+  alumnoId: string;
+  docenteId: string;
+  estado: OrientacionRequestEstado;
+  fechaSolicitud: string;
+  fechaRespuesta: string | null;
+  observaciones: string | null;
+}
+
+export interface OrientacionPlan {
+  id: string;
+  casoId: string;
+  objetivo: string;
+  acciones: string;
+  responsable: string;
+  fechaInicio: string;
+  fechaRevision: string | null;
+  estado: string;
+}
+
+export interface OrientacionFollowUp {
+  id: string;
+  casoId: string;
+  tipo: string;
+  descripcion: string;
+  evidenciaUrl: string | null;
+  createdBy: string | null;
+  createdAt: string;
+}
+
+export interface OrientacionHistoryItem {
+  id: string;
+  fecha: string;
+  titulo: string;
+  detalle: string;
+  fuente: string;
+}
+
+export const ORIENTACION_CASE_LABELS: Record<OrientacionCaseEstado, string> = {
+  recibido: "Recibido",
+  en_analisis: "En análisis",
+  diagnostico_solicitado: "Diagnóstico solicitado",
+  plan_definido: "Plan definido",
+  derivado_trabajo_social: "Derivado a Trabajo Social",
+  escalado_direccion: "Escalado a Dirección",
+  cerrado: "Cerrado",
+};
+
+export const ORIENTACION_PRIORITY_LABELS: Record<OrientacionCasePrioridad, string> = {
+  baja: "Baja",
+  media: "Media",
+  alta: "Alta",
+  critica: "Crítica",
+};
+
+export const ORIENTACION_PRIORITY_STYLES: Record<OrientacionCasePrioridad, string> = {
+  baja: "bg-emerald-500/15 text-emerald-200 border-emerald-400/20",
+  media: "bg-violet-500/15 text-violet-200 border-violet-400/20",
+  alta: "bg-amber-500/15 text-amber-200 border-amber-400/20",
+  critica: "bg-rose-500/15 text-rose-200 border-rose-400/20",
+};
+
+export const ORIENTACION_STATE_STYLES: Record<OrientacionCaseEstado, string> = {
+  recibido: "bg-slate-500/15 text-slate-200 border-slate-400/20",
+  en_analisis: "bg-cyan-500/15 text-cyan-200 border-cyan-400/20",
+  diagnostico_solicitado: "bg-fuchsia-500/15 text-fuchsia-200 border-fuchsia-400/20",
+  plan_definido: "bg-indigo-500/15 text-indigo-200 border-indigo-400/20",
+  derivado_trabajo_social: "bg-amber-500/15 text-amber-200 border-amber-400/20",
+  escalado_direccion: "bg-rose-500/15 text-rose-200 border-rose-400/20",
+  cerrado: "bg-emerald-500/15 text-emerald-200 border-emerald-400/20",
+};

--- a/src/supabase/types.ts
+++ b/src/supabase/types.ts
@@ -1401,6 +1401,269 @@ export type Database = {
           },
         ]
       }
+      orientacion_casos: {
+        Row: {
+          alumno_id: string
+          creado_por: string | null
+          estado: string
+          fecha_actualizacion: string
+          fecha_apertura: string
+          id: string
+          motivo: string
+          prioridad: string
+          responsable_id: string | null
+          resumen: string | null
+        }
+        Insert: {
+          alumno_id: string
+          creado_por?: string | null
+          estado?: string
+          fecha_actualizacion?: string
+          fecha_apertura?: string
+          id?: string
+          motivo: string
+          prioridad?: string
+          responsable_id?: string | null
+          resumen?: string | null
+        }
+        Update: {
+          alumno_id?: string
+          creado_por?: string | null
+          estado?: string
+          fecha_actualizacion?: string
+          fecha_apertura?: string
+          id?: string
+          motivo?: string
+          prioridad?: string
+          responsable_id?: string | null
+          resumen?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "orientacion_casos_alumno_id_fkey"
+            columns: ["alumno_id"]
+            isOneToOne: false
+            referencedRelation: "alumnos"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "orientacion_casos_creado_por_fkey"
+            columns: ["creado_por"]
+            isOneToOne: false
+            referencedRelation: "perfiles_usuario"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "orientacion_casos_responsable_id_fkey"
+            columns: ["responsable_id"]
+            isOneToOne: false
+            referencedRelation: "perfiles_usuario"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      solicitudes_diagnostico: {
+        Row: {
+          alumno_id: string
+          caso_id: string
+          docente_id: string
+          estado: string
+          fecha_respuesta: string | null
+          fecha_solicitud: string
+          id: string
+          observaciones: string | null
+        }
+        Insert: {
+          alumno_id: string
+          caso_id: string
+          docente_id: string
+          estado?: string
+          fecha_respuesta?: string | null
+          fecha_solicitud?: string
+          id?: string
+          observaciones?: string | null
+        }
+        Update: {
+          alumno_id?: string
+          caso_id?: string
+          docente_id?: string
+          estado?: string
+          fecha_respuesta?: string | null
+          fecha_solicitud?: string
+          id?: string
+          observaciones?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "solicitudes_diagnostico_alumno_id_fkey"
+            columns: ["alumno_id"]
+            isOneToOne: false
+            referencedRelation: "alumnos"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "solicitudes_diagnostico_caso_id_fkey"
+            columns: ["caso_id"]
+            isOneToOne: false
+            referencedRelation: "orientacion_casos"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "solicitudes_diagnostico_docente_id_fkey"
+            columns: ["docente_id"]
+            isOneToOne: false
+            referencedRelation: "perfiles_usuario"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      diagnosticos_docentes: {
+        Row: {
+          aprovechamiento: string | null
+          asistencia: string | null
+          caso_id: string
+          conducta: string | null
+          created_at: string
+          docente_id: string
+          id: string
+          observaciones: string | null
+          recomendaciones: string | null
+          solicitud_id: string
+        }
+        Insert: {
+          aprovechamiento?: string | null
+          asistencia?: string | null
+          caso_id: string
+          conducta?: string | null
+          created_at?: string
+          docente_id: string
+          id?: string
+          observaciones?: string | null
+          recomendaciones?: string | null
+          solicitud_id: string
+        }
+        Update: {
+          aprovechamiento?: string | null
+          asistencia?: string | null
+          caso_id?: string
+          conducta?: string | null
+          created_at?: string
+          docente_id?: string
+          id?: string
+          observaciones?: string | null
+          recomendaciones?: string | null
+          solicitud_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "diagnosticos_docentes_caso_id_fkey"
+            columns: ["caso_id"]
+            isOneToOne: false
+            referencedRelation: "orientacion_casos"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "diagnosticos_docentes_docente_id_fkey"
+            columns: ["docente_id"]
+            isOneToOne: false
+            referencedRelation: "perfiles_usuario"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "diagnosticos_docentes_solicitud_id_fkey"
+            columns: ["solicitud_id"]
+            isOneToOne: false
+            referencedRelation: "solicitudes_diagnostico"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      planes_intervencion: {
+        Row: {
+          acciones: string
+          caso_id: string
+          estado: string
+          fecha_inicio: string
+          fecha_revision: string | null
+          id: string
+          objetivo: string
+          responsable: string
+        }
+        Insert: {
+          acciones: string
+          caso_id: string
+          estado?: string
+          fecha_inicio?: string
+          fecha_revision?: string | null
+          id?: string
+          objetivo: string
+          responsable: string
+        }
+        Update: {
+          acciones?: string
+          caso_id?: string
+          estado?: string
+          fecha_inicio?: string
+          fecha_revision?: string | null
+          id?: string
+          objetivo?: string
+          responsable?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "planes_intervencion_caso_id_fkey"
+            columns: ["caso_id"]
+            isOneToOne: false
+            referencedRelation: "orientacion_casos"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      seguimiento_orientacion: {
+        Row: {
+          caso_id: string
+          created_at: string
+          created_by: string | null
+          descripcion: string
+          evidencia_url: string | null
+          id: string
+          tipo: string
+        }
+        Insert: {
+          caso_id: string
+          created_at?: string
+          created_by?: string | null
+          descripcion: string
+          evidencia_url?: string | null
+          id?: string
+          tipo: string
+        }
+        Update: {
+          caso_id?: string
+          created_at?: string
+          created_by?: string | null
+          descripcion?: string
+          evidencia_url?: string | null
+          id?: string
+          tipo?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "seguimiento_orientacion_caso_id_fkey"
+            columns: ["caso_id"]
+            isOneToOne: false
+            referencedRelation: "orientacion_casos"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "seguimiento_orientacion_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "perfiles_usuario"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       justificantes: {
         Row: {
           alumno_id: string | null
@@ -2785,6 +3048,45 @@ export type Database = {
         }
         Returns: string
       }
+      abrir_caso_orientacion: {
+        Args: {
+          p_alumno_id: string
+          p_motivo: string
+          p_prioridad?: string
+          p_responsable_id?: string | null
+          p_resumen?: string | null
+        }
+        Returns: string
+      }
+      audit_orientacion_action: {
+        Args: {
+          p_descripcion: string
+          p_id_registro: string
+          p_new_values?: Json | null
+          p_tabla: string
+          p_tipo_accion: string
+        }
+        Returns: string
+      }
+      crear_plan_intervencion: {
+        Args: {
+          p_acciones: string
+          p_caso_id: string
+          p_estado?: string
+          p_fecha_inicio?: string
+          p_fecha_revision?: string | null
+          p_objetivo: string
+          p_responsable: string
+        }
+        Returns: string
+      }
+      derivar_trabajo_social: {
+        Args: {
+          p_caso_id: string
+          p_descripcion?: string
+        }
+        Returns: undefined
+      }
       registrar_auditoria_sase: {
         Args: {
           p_descripcion: string
@@ -2797,8 +3099,34 @@ export type Database = {
         }
         Returns: string
       }
+      registrar_diagnostico: {
+        Args: {
+          p_asistencia?: string
+          p_conducta?: string
+          p_observaciones?: string
+          p_recomendaciones?: string
+          p_solicitud_id: string
+          p_aprovechamiento?: string
+        }
+        Returns: string
+      }
       registrar_behavior_metric: {
         Args: { p_alumno_id: string }
+        Returns: undefined
+      }
+      solicitar_diagnostico: {
+        Args: {
+          p_caso_id: string
+          p_docente_id: string
+          p_observaciones?: string | null
+        }
+        Returns: string
+      }
+      escalar_direccion: {
+        Args: {
+          p_caso_id: string
+          p_descripcion?: string
+        }
         Returns: undefined
       }
       simular_promocion: {
@@ -3012,4 +3340,3 @@ export const Constants = {
     },
   },
 } as const
-

--- a/src/utils/permisos.ts
+++ b/src/utils/permisos.ts
@@ -80,7 +80,7 @@ export const PERMISOS_POR_ROL: Record<string, PermisosSASE> = {
     can_view_names: true,
     can_register: true,
     can_edit: true,
-    can_close: true,
+    can_close: false,
     can_escalate: true,
     can_view_audit: false,
     can_approve_staff: false,

--- a/supabase/migrations/20260501084547_orientacion_v2_backend.sql
+++ b/supabase/migrations/20260501084547_orientacion_v2_backend.sql
@@ -1,0 +1,823 @@
+-- Orientacion v2: backend institucional minimo.
+-- Diagnostico previo: no existen tablas de caso/plan/diagnostico de Orientacion.
+-- Se reutilizan alumnos, incidencias, expediente_integral_alumno, citas_padres,
+-- contacts_log, interventions_log y seguimiento_social sin duplicar su dominio.
+
+create table if not exists public.orientacion_casos (
+  id uuid primary key default gen_random_uuid(),
+  alumno_id uuid not null references public.alumnos(id) on delete cascade,
+  creado_por uuid references public.perfiles_usuario(id) on delete set null,
+  responsable_id uuid references public.perfiles_usuario(id) on delete set null,
+  estado text not null default 'recibido',
+  prioridad text not null default 'media',
+  motivo text not null,
+  resumen text,
+  fecha_apertura timestamptz not null default now(),
+  fecha_actualizacion timestamptz not null default now(),
+  constraint orientacion_casos_estado_check check (estado in (
+    'recibido',
+    'en_analisis',
+    'diagnostico_solicitado',
+    'plan_definido',
+    'derivado_trabajo_social',
+    'escalado_direccion',
+    'cerrado'
+  )),
+  constraint orientacion_casos_prioridad_check check (prioridad in ('baja', 'media', 'alta', 'critica'))
+);
+
+create table if not exists public.solicitudes_diagnostico (
+  id uuid primary key default gen_random_uuid(),
+  caso_id uuid not null references public.orientacion_casos(id) on delete cascade,
+  docente_id uuid not null references public.perfiles_usuario(id) on delete cascade,
+  alumno_id uuid not null references public.alumnos(id) on delete cascade,
+  estado text not null default 'pendiente',
+  fecha_solicitud timestamptz not null default now(),
+  fecha_respuesta timestamptz,
+  observaciones text,
+  constraint solicitudes_diagnostico_estado_check check (estado in ('pendiente', 'respondido', 'vencido'))
+);
+
+create table if not exists public.diagnosticos_docentes (
+  id uuid primary key default gen_random_uuid(),
+  solicitud_id uuid not null references public.solicitudes_diagnostico(id) on delete cascade,
+  caso_id uuid not null references public.orientacion_casos(id) on delete cascade,
+  docente_id uuid not null references public.perfiles_usuario(id) on delete cascade,
+  conducta text,
+  aprovechamiento text,
+  asistencia text,
+  observaciones text,
+  recomendaciones text,
+  created_at timestamptz not null default now(),
+  constraint diagnosticos_docentes_solicitud_unique unique (solicitud_id)
+);
+
+create table if not exists public.planes_intervencion (
+  id uuid primary key default gen_random_uuid(),
+  caso_id uuid not null references public.orientacion_casos(id) on delete cascade,
+  objetivo text not null,
+  acciones text not null,
+  responsable text not null,
+  fecha_inicio date not null default current_date,
+  fecha_revision date,
+  estado text not null default 'activo',
+  constraint planes_intervencion_estado_check check (estado in ('borrador', 'activo', 'en_revision', 'ajustado', 'concluido'))
+);
+
+create table if not exists public.seguimiento_orientacion (
+  id uuid primary key default gen_random_uuid(),
+  caso_id uuid not null references public.orientacion_casos(id) on delete cascade,
+  tipo text not null,
+  descripcion text not null,
+  evidencia_url text,
+  created_by uuid references public.perfiles_usuario(id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint seguimiento_orientacion_tipo_check check (tipo in (
+    'nota',
+    'entrevista',
+    'diagnostico',
+    'plan',
+    'derivacion',
+    'escalamiento',
+    'evidencia'
+  ))
+);
+
+create index if not exists idx_orientacion_casos_alumno on public.orientacion_casos(alumno_id);
+create index if not exists idx_orientacion_casos_responsable on public.orientacion_casos(responsable_id);
+create index if not exists idx_orientacion_casos_estado on public.orientacion_casos(estado);
+create index if not exists idx_solicitudes_diagnostico_caso on public.solicitudes_diagnostico(caso_id);
+create index if not exists idx_solicitudes_diagnostico_docente on public.solicitudes_diagnostico(docente_id);
+create index if not exists idx_solicitudes_diagnostico_alumno on public.solicitudes_diagnostico(alumno_id);
+create index if not exists idx_diagnosticos_docentes_caso on public.diagnosticos_docentes(caso_id);
+create index if not exists idx_diagnosticos_docentes_docente on public.diagnosticos_docentes(docente_id);
+create index if not exists idx_planes_intervencion_caso on public.planes_intervencion(caso_id);
+create index if not exists idx_seguimiento_orientacion_caso on public.seguimiento_orientacion(caso_id);
+create index if not exists idx_seguimiento_orientacion_created_by on public.seguimiento_orientacion(created_by);
+
+create or replace function public.set_orientacion_fecha_actualizacion()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.fecha_actualizacion = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists tr_orientacion_casos_fecha_actualizacion on public.orientacion_casos;
+create trigger tr_orientacion_casos_fecha_actualizacion
+before update on public.orientacion_casos
+for each row execute function public.set_orientacion_fecha_actualizacion();
+
+alter table public.orientacion_casos enable row level security;
+alter table public.solicitudes_diagnostico enable row level security;
+alter table public.diagnosticos_docentes enable row level security;
+alter table public.planes_intervencion enable row level security;
+alter table public.seguimiento_orientacion enable row level security;
+
+grant select, insert, update on public.orientacion_casos to authenticated;
+grant select, insert, update on public.solicitudes_diagnostico to authenticated;
+grant select, insert on public.diagnosticos_docentes to authenticated;
+grant select, insert, update on public.planes_intervencion to authenticated;
+grant select, insert on public.seguimiento_orientacion to authenticated;
+grant all on public.orientacion_casos to service_role;
+grant all on public.solicitudes_diagnostico to service_role;
+grant all on public.diagnosticos_docentes to service_role;
+grant all on public.planes_intervencion to service_role;
+grant all on public.seguimiento_orientacion to service_role;
+
+drop policy if exists "Admin total orientacion casos" on public.orientacion_casos;
+create policy "Admin total orientacion casos"
+on public.orientacion_casos
+for all
+to authenticated
+using (public.get_my_role_text() in ('developer', 'system_admin'))
+with check (public.get_my_role_text() in ('developer', 'system_admin'));
+
+drop policy if exists "Orientacion ve sus casos" on public.orientacion_casos;
+create policy "Orientacion ve sus casos"
+on public.orientacion_casos
+for select
+to authenticated
+using (
+  public.get_my_role_text() = 'orientacion'
+  and (creado_por = auth.uid() or responsable_id = auth.uid())
+);
+
+drop policy if exists "Direccion subdireccion ven casos orientacion" on public.orientacion_casos;
+create policy "Direccion subdireccion ven casos orientacion"
+on public.orientacion_casos
+for select
+to authenticated
+using (public.get_my_role_text() in ('directivo', 'subdireccion'));
+
+drop policy if exists "Trabajo social ve derivados orientacion" on public.orientacion_casos;
+create policy "Trabajo social ve derivados orientacion"
+on public.orientacion_casos
+for select
+to authenticated
+using (
+  public.get_my_role_text() = 'trabajo_social'
+  and estado = 'derivado_trabajo_social'
+);
+
+drop policy if exists "Orientacion crea sus casos" on public.orientacion_casos;
+create policy "Orientacion crea sus casos"
+on public.orientacion_casos
+for insert
+to authenticated
+with check (
+  public.get_my_role_text() = 'orientacion'
+  and creado_por = auth.uid()
+  and (responsable_id is null or responsable_id = auth.uid())
+  and estado <> 'cerrado'
+);
+
+drop policy if exists "Orientacion edita sus casos sin cierre" on public.orientacion_casos;
+create policy "Orientacion edita sus casos sin cierre"
+on public.orientacion_casos
+for update
+to authenticated
+using (
+  public.get_my_role_text() = 'orientacion'
+  and (creado_por = auth.uid() or responsable_id = auth.uid())
+)
+with check (
+  public.get_my_role_text() = 'orientacion'
+  and (creado_por = auth.uid() or responsable_id = auth.uid())
+  and estado <> 'cerrado'
+);
+
+drop policy if exists "Admin total solicitudes diagnostico" on public.solicitudes_diagnostico;
+create policy "Admin total solicitudes diagnostico"
+on public.solicitudes_diagnostico
+for all
+to authenticated
+using (public.get_my_role_text() in ('developer', 'system_admin'))
+with check (public.get_my_role_text() in ('developer', 'system_admin'));
+
+drop policy if exists "Orientacion gestiona solicitudes diagnostico" on public.solicitudes_diagnostico;
+create policy "Orientacion gestiona solicitudes diagnostico"
+on public.solicitudes_diagnostico
+for all
+to authenticated
+using (
+  public.get_my_role_text() = 'orientacion'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+  )
+)
+with check (
+  public.get_my_role_text() = 'orientacion'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+  )
+);
+
+drop policy if exists "Direccion subdireccion ven solicitudes diagnostico" on public.solicitudes_diagnostico;
+create policy "Direccion subdireccion ven solicitudes diagnostico"
+on public.solicitudes_diagnostico
+for select
+to authenticated
+using (public.get_my_role_text() in ('directivo', 'subdireccion'));
+
+drop policy if exists "Docente responde solicitudes asignadas" on public.solicitudes_diagnostico;
+create policy "Docente responde solicitudes asignadas"
+on public.solicitudes_diagnostico
+for select
+to authenticated
+using (
+  public.get_my_role_text() in ('docente', 'docente_tutor')
+  and docente_id = auth.uid()
+);
+
+drop policy if exists "Docente actualiza solicitudes asignadas" on public.solicitudes_diagnostico;
+create policy "Docente actualiza solicitudes asignadas"
+on public.solicitudes_diagnostico
+for update
+to authenticated
+using (
+  public.get_my_role_text() in ('docente', 'docente_tutor')
+  and docente_id = auth.uid()
+)
+with check (
+  public.get_my_role_text() in ('docente', 'docente_tutor')
+  and docente_id = auth.uid()
+);
+
+drop policy if exists "Admin total diagnosticos docentes" on public.diagnosticos_docentes;
+create policy "Admin total diagnosticos docentes"
+on public.diagnosticos_docentes
+for all
+to authenticated
+using (public.get_my_role_text() in ('developer', 'system_admin'))
+with check (public.get_my_role_text() in ('developer', 'system_admin'));
+
+drop policy if exists "Orientacion ve diagnosticos de sus casos" on public.diagnosticos_docentes;
+create policy "Orientacion ve diagnosticos de sus casos"
+on public.diagnosticos_docentes
+for select
+to authenticated
+using (
+  public.get_my_role_text() = 'orientacion'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+  )
+);
+
+drop policy if exists "Direccion subdireccion ven diagnosticos" on public.diagnosticos_docentes;
+create policy "Direccion subdireccion ven diagnosticos"
+on public.diagnosticos_docentes
+for select
+to authenticated
+using (public.get_my_role_text() in ('directivo', 'subdireccion'));
+
+drop policy if exists "Docente inserta diagnostico asignado" on public.diagnosticos_docentes;
+create policy "Docente inserta diagnostico asignado"
+on public.diagnosticos_docentes
+for insert
+to authenticated
+with check (
+  public.get_my_role_text() in ('docente', 'docente_tutor')
+  and docente_id = auth.uid()
+  and exists (
+    select 1
+    from public.solicitudes_diagnostico s
+    where s.id = solicitud_id
+      and s.caso_id = caso_id
+      and s.docente_id = auth.uid()
+      and s.estado = 'pendiente'
+  )
+);
+
+drop policy if exists "Docente ve diagnostico propio" on public.diagnosticos_docentes;
+create policy "Docente ve diagnostico propio"
+on public.diagnosticos_docentes
+for select
+to authenticated
+using (
+  public.get_my_role_text() in ('docente', 'docente_tutor')
+  and docente_id = auth.uid()
+);
+
+drop policy if exists "Admin total planes intervencion" on public.planes_intervencion;
+create policy "Admin total planes intervencion"
+on public.planes_intervencion
+for all
+to authenticated
+using (public.get_my_role_text() in ('developer', 'system_admin'))
+with check (public.get_my_role_text() in ('developer', 'system_admin'));
+
+drop policy if exists "Orientacion gestiona planes propios" on public.planes_intervencion;
+create policy "Orientacion gestiona planes propios"
+on public.planes_intervencion
+for all
+to authenticated
+using (
+  public.get_my_role_text() = 'orientacion'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+      and c.estado <> 'cerrado'
+  )
+)
+with check (
+  public.get_my_role_text() = 'orientacion'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+      and c.estado <> 'cerrado'
+  )
+);
+
+drop policy if exists "Direccion subdireccion ven planes" on public.planes_intervencion;
+create policy "Direccion subdireccion ven planes"
+on public.planes_intervencion
+for select
+to authenticated
+using (public.get_my_role_text() in ('directivo', 'subdireccion'));
+
+drop policy if exists "Trabajo social ve planes derivados" on public.planes_intervencion;
+create policy "Trabajo social ve planes derivados"
+on public.planes_intervencion
+for select
+to authenticated
+using (
+  public.get_my_role_text() = 'trabajo_social'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and c.estado = 'derivado_trabajo_social'
+  )
+);
+
+drop policy if exists "Admin total seguimiento orientacion" on public.seguimiento_orientacion;
+create policy "Admin total seguimiento orientacion"
+on public.seguimiento_orientacion
+for all
+to authenticated
+using (public.get_my_role_text() in ('developer', 'system_admin'))
+with check (public.get_my_role_text() in ('developer', 'system_admin'));
+
+drop policy if exists "Orientacion gestiona seguimiento propio" on public.seguimiento_orientacion;
+create policy "Orientacion gestiona seguimiento propio"
+on public.seguimiento_orientacion
+for all
+to authenticated
+using (
+  public.get_my_role_text() = 'orientacion'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+      and c.estado <> 'cerrado'
+  )
+)
+with check (
+  public.get_my_role_text() = 'orientacion'
+  and created_by = auth.uid()
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and (c.creado_por = auth.uid() or c.responsable_id = auth.uid())
+      and c.estado <> 'cerrado'
+  )
+);
+
+drop policy if exists "Direccion subdireccion ven seguimiento orientacion" on public.seguimiento_orientacion;
+create policy "Direccion subdireccion ven seguimiento orientacion"
+on public.seguimiento_orientacion
+for select
+to authenticated
+using (public.get_my_role_text() in ('directivo', 'subdireccion'));
+
+drop policy if exists "Trabajo social ve seguimiento derivado" on public.seguimiento_orientacion;
+create policy "Trabajo social ve seguimiento derivado"
+on public.seguimiento_orientacion
+for select
+to authenticated
+using (
+  public.get_my_role_text() = 'trabajo_social'
+  and exists (
+    select 1
+    from public.orientacion_casos c
+    where c.id = caso_id
+      and c.estado = 'derivado_trabajo_social'
+  )
+);
+
+create or replace function public.audit_orientacion_action(
+  p_tipo_accion text,
+  p_descripcion text,
+  p_tabla text,
+  p_id_registro text,
+  p_new_values jsonb default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_audit_id uuid;
+begin
+  insert into public.auditoria (
+    usuario_id,
+    email_usuario,
+    rol_usuario,
+    tipo_accion,
+    descripcion_accion,
+    tabla_objetivo,
+    id_registro_objetivo,
+    nuevos_valores
+  ) values (
+    auth.uid(),
+    auth.jwt() ->> 'email',
+    public.get_my_role_text(),
+    p_tipo_accion,
+    p_descripcion,
+    p_tabla,
+    p_id_registro,
+    p_new_values
+  )
+  returning id into v_audit_id;
+
+  return v_audit_id;
+end;
+$$;
+
+create or replace function public.abrir_caso_orientacion(
+  p_alumno_id uuid,
+  p_motivo text,
+  p_resumen text default null,
+  p_prioridad text default 'media',
+  p_responsable_id uuid default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text := public.get_my_role_text();
+  v_case_id uuid;
+  v_responsable uuid := coalesce(p_responsable_id, auth.uid());
+begin
+  if auth.uid() is null or v_role not in ('orientacion', 'developer', 'system_admin') then
+    raise exception 'No autorizado para abrir casos de Orientacion' using errcode = '42501';
+  end if;
+
+  insert into public.orientacion_casos (
+    alumno_id,
+    creado_por,
+    responsable_id,
+    estado,
+    prioridad,
+    motivo,
+    resumen
+  ) values (
+    p_alumno_id,
+    auth.uid(),
+    v_responsable,
+    'recibido',
+    coalesce(nullif(p_prioridad, ''), 'media'),
+    p_motivo,
+    p_resumen
+  )
+  returning id into v_case_id;
+
+  perform public.audit_orientacion_action(
+    'ORIENTACION_CASO_ABIERTO',
+    'Caso de Orientacion abierto',
+    'orientacion_casos',
+    v_case_id::text,
+    jsonb_build_object('alumno_id', p_alumno_id, 'prioridad', p_prioridad, 'motivo', p_motivo)
+  );
+
+  return v_case_id;
+end;
+$$;
+
+create or replace function public.solicitar_diagnostico(
+  p_docente_id uuid,
+  p_caso_id uuid,
+  p_observaciones text default null
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text := public.get_my_role_text();
+  v_alumno_id uuid;
+  v_request_id uuid;
+begin
+  if auth.uid() is null or v_role not in ('orientacion', 'developer', 'system_admin') then
+    raise exception 'No autorizado para solicitar diagnosticos docentes' using errcode = '42501';
+  end if;
+
+  if not exists (
+    select 1
+    from public.perfiles_usuario p
+    where p.id = p_docente_id
+      and p.rol in ('docente', 'docente_tutor')
+  ) then
+    raise exception 'El destinatario no es docente institucional' using errcode = '23514';
+  end if;
+
+  select alumno_id into v_alumno_id
+  from public.orientacion_casos
+  where id = p_caso_id;
+
+  if v_alumno_id is null then
+    raise exception 'Caso de Orientacion no encontrado o no visible' using errcode = '42501';
+  end if;
+
+  insert into public.solicitudes_diagnostico (
+    caso_id,
+    docente_id,
+    alumno_id,
+    estado,
+    observaciones
+  ) values (
+    p_caso_id,
+    p_docente_id,
+    v_alumno_id,
+    'pendiente',
+    p_observaciones
+  )
+  returning id into v_request_id;
+
+  update public.orientacion_casos
+  set estado = 'diagnostico_solicitado'
+  where id = p_caso_id;
+
+  perform public.audit_orientacion_action(
+    'ORIENTACION_DIAGNOSTICO_SOLICITADO',
+    'Diagnostico docente solicitado por Orientacion',
+    'solicitudes_diagnostico',
+    v_request_id::text,
+    jsonb_build_object('caso_id', p_caso_id, 'docente_id', p_docente_id)
+  );
+
+  return v_request_id;
+end;
+$$;
+
+create or replace function public.registrar_diagnostico(
+  p_solicitud_id uuid,
+  p_conducta text,
+  p_aprovechamiento text,
+  p_asistencia text,
+  p_observaciones text,
+  p_recomendaciones text
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text := public.get_my_role_text();
+  v_request public.solicitudes_diagnostico%rowtype;
+  v_diagnostico_id uuid;
+begin
+  if auth.uid() is null or v_role not in ('docente', 'docente_tutor', 'developer', 'system_admin') then
+    raise exception 'No autorizado para registrar diagnostico docente' using errcode = '42501';
+  end if;
+
+  select * into v_request
+  from public.solicitudes_diagnostico
+  where id = p_solicitud_id
+    and (docente_id = auth.uid() or v_role in ('developer', 'system_admin'));
+
+  if v_request.id is null then
+    raise exception 'Solicitud de diagnostico no encontrada o no asignada' using errcode = '42501';
+  end if;
+
+  if v_request.estado <> 'pendiente' then
+    raise exception 'La solicitud de diagnostico ya no esta pendiente' using errcode = '23514';
+  end if;
+
+  insert into public.diagnosticos_docentes (
+    solicitud_id,
+    caso_id,
+    docente_id,
+    conducta,
+    aprovechamiento,
+    asistencia,
+    observaciones,
+    recomendaciones
+  ) values (
+    v_request.id,
+    v_request.caso_id,
+    v_request.docente_id,
+    p_conducta,
+    p_aprovechamiento,
+    p_asistencia,
+    p_observaciones,
+    p_recomendaciones
+  )
+  returning id into v_diagnostico_id;
+
+  update public.solicitudes_diagnostico
+  set estado = 'respondido', fecha_respuesta = now()
+  where id = p_solicitud_id;
+
+  perform public.audit_orientacion_action(
+    'ORIENTACION_DIAGNOSTICO_REGISTRADO',
+    'Diagnostico docente respondido',
+    'diagnosticos_docentes',
+    v_diagnostico_id::text,
+    jsonb_build_object('caso_id', v_request.caso_id, 'solicitud_id', p_solicitud_id)
+  );
+
+  return v_diagnostico_id;
+end;
+$$;
+
+create or replace function public.crear_plan_intervencion(
+  p_caso_id uuid,
+  p_objetivo text,
+  p_acciones text,
+  p_responsable text,
+  p_fecha_inicio date default current_date,
+  p_fecha_revision date default null,
+  p_estado text default 'activo'
+)
+returns uuid
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text := public.get_my_role_text();
+  v_plan_id uuid;
+begin
+  if auth.uid() is null or v_role not in ('orientacion', 'developer', 'system_admin') then
+    raise exception 'No autorizado para crear planes de intervencion' using errcode = '42501';
+  end if;
+
+  if not exists (select 1 from public.orientacion_casos where id = p_caso_id) then
+    raise exception 'Caso de Orientacion no encontrado o no visible' using errcode = '42501';
+  end if;
+
+  insert into public.planes_intervencion (
+    caso_id,
+    objetivo,
+    acciones,
+    responsable,
+    fecha_inicio,
+    fecha_revision,
+    estado
+  ) values (
+    p_caso_id,
+    p_objetivo,
+    p_acciones,
+    p_responsable,
+    coalesce(p_fecha_inicio, current_date),
+    p_fecha_revision,
+    coalesce(nullif(p_estado, ''), 'activo')
+  )
+  returning id into v_plan_id;
+
+  update public.orientacion_casos
+  set estado = 'plan_definido'
+  where id = p_caso_id;
+
+  insert into public.seguimiento_orientacion (caso_id, tipo, descripcion, created_by)
+  values (p_caso_id, 'plan', 'Plan de intervencion definido por Orientacion.', auth.uid());
+
+  perform public.audit_orientacion_action(
+    'ORIENTACION_PLAN_CREADO',
+    'Plan de intervencion creado',
+    'planes_intervencion',
+    v_plan_id::text,
+    jsonb_build_object('caso_id', p_caso_id, 'estado', p_estado)
+  );
+
+  return v_plan_id;
+end;
+$$;
+
+create or replace function public.derivar_trabajo_social(
+  p_caso_id uuid,
+  p_descripcion text default 'Caso derivado a Trabajo Social por Orientacion.'
+)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text := public.get_my_role_text();
+begin
+  if auth.uid() is null or v_role not in ('orientacion', 'developer', 'system_admin') then
+    raise exception 'No autorizado para derivar a Trabajo Social' using errcode = '42501';
+  end if;
+
+  update public.orientacion_casos
+  set estado = 'derivado_trabajo_social'
+  where id = p_caso_id;
+
+  if not found then
+    raise exception 'Caso de Orientacion no encontrado o no visible' using errcode = '42501';
+  end if;
+
+  insert into public.seguimiento_orientacion (caso_id, tipo, descripcion, created_by)
+  values (p_caso_id, 'derivacion', p_descripcion, auth.uid());
+
+  perform public.audit_orientacion_action(
+    'ORIENTACION_DERIVADO_TRABAJO_SOCIAL',
+    'Caso derivado a Trabajo Social',
+    'orientacion_casos',
+    p_caso_id::text,
+    jsonb_build_object('estado', 'derivado_trabajo_social')
+  );
+end;
+$$;
+
+create or replace function public.escalar_direccion(
+  p_caso_id uuid,
+  p_descripcion text default 'Caso escalado a Direccion para decision institucional.'
+)
+returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_role text := public.get_my_role_text();
+begin
+  if auth.uid() is null or v_role not in ('orientacion', 'developer', 'system_admin') then
+    raise exception 'No autorizado para escalar a Direccion' using errcode = '42501';
+  end if;
+
+  update public.orientacion_casos
+  set estado = 'escalado_direccion'
+  where id = p_caso_id;
+
+  if not found then
+    raise exception 'Caso de Orientacion no encontrado o no visible' using errcode = '42501';
+  end if;
+
+  insert into public.seguimiento_orientacion (caso_id, tipo, descripcion, created_by)
+  values (p_caso_id, 'escalamiento', p_descripcion, auth.uid());
+
+  perform public.audit_orientacion_action(
+    'ORIENTACION_ESCALADO_DIRECCION',
+    'Caso escalado a Direccion',
+    'orientacion_casos',
+    p_caso_id::text,
+    jsonb_build_object('estado', 'escalado_direccion')
+  );
+end;
+$$;
+
+revoke all on function public.audit_orientacion_action(text, text, text, text, jsonb) from public, anon;
+revoke all on function public.abrir_caso_orientacion(uuid, text, text, text, uuid) from public, anon;
+revoke all on function public.solicitar_diagnostico(uuid, uuid, text) from public, anon;
+revoke all on function public.registrar_diagnostico(uuid, text, text, text, text, text) from public, anon;
+revoke all on function public.crear_plan_intervencion(uuid, text, text, text, date, date, text) from public, anon;
+revoke all on function public.derivar_trabajo_social(uuid, text) from public, anon;
+revoke all on function public.escalar_direccion(uuid, text) from public, anon;
+
+grant execute on function public.abrir_caso_orientacion(uuid, text, text, text, uuid) to authenticated, service_role;
+grant execute on function public.audit_orientacion_action(text, text, text, text, jsonb) to authenticated, service_role;
+grant execute on function public.solicitar_diagnostico(uuid, uuid, text) to authenticated, service_role;
+grant execute on function public.registrar_diagnostico(uuid, text, text, text, text, text) to authenticated, service_role;
+grant execute on function public.crear_plan_intervencion(uuid, text, text, text, date, date, text) to authenticated, service_role;
+grant execute on function public.derivar_trabajo_social(uuid, text) to authenticated, service_role;
+grant execute on function public.escalar_direccion(uuid, text) to authenticated, service_role;
+
+comment on table public.orientacion_casos is 'Casos institucionales gestionados por Orientacion. No reemplaza incidencias ni seguimiento social.';
+comment on table public.solicitudes_diagnostico is 'Solicitudes de diagnostico docente asignadas desde casos de Orientacion.';
+comment on table public.diagnosticos_docentes is 'Respuestas docentes a solicitudes formales de Orientacion.';
+comment on table public.planes_intervencion is 'Planes de intervencion definidos por Orientacion para casos activos.';
+comment on table public.seguimiento_orientacion is 'Bitacora y evidencia de seguimiento propio de Orientacion.';
+
+insert into public.auditoria (tipo_accion, descripcion_accion, tabla_objetivo)
+values (
+  'ORIENTACION_V2_BACKEND',
+  'Backend base de Orientacion v2: casos, diagnosticos docentes, planes, seguimiento y RLS minimo.',
+  'orientacion_casos'
+);

--- a/tests/DashboardOrientacion.test.tsx
+++ b/tests/DashboardOrientacion.test.tsx
@@ -1,114 +1,130 @@
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import { DashboardOrientacion } from "../src/components/dashboards/DashboardOrientacion";
-import { CaseState } from "../src/types";
 
 const mocks = vi.hoisted(() => ({
-  setCurrentModule: vi.fn(),
-  addIncident: vi.fn(),
+  openCase: vi.fn(),
+  requestDiagnosis: vi.fn(),
+  createPlan: vi.fn(),
+  deriveSocialWork: vi.fn(),
+  escalateDirection: vi.fn(),
+  loadCases: vi.fn(),
+  loadDocentes: vi.fn(),
+  loadHistory: vi.fn(),
+  print: vi.fn(),
+}));
+
+vi.mock("../src/components/orientacion/orientacionApi", () => ({
+  abrirCasoOrientacion: mocks.openCase,
+  solicitarDiagnostico: mocks.requestDiagnosis,
+  crearPlanIntervencion: mocks.createPlan,
+  derivarTrabajoSocial: mocks.deriveSocialWork,
+  escalarDireccion: mocks.escalateDirection,
+  loadOrientacionCasos: mocks.loadCases,
+  loadDocentes: mocks.loadDocentes,
+  loadStudentHistory: mocks.loadHistory,
 }));
 
 vi.mock("../src/store", () => ({
   useApp: () => ({
     students: [
       {
-        id: "1",
-        name: "Pattern Student",
+        id: "student-1",
+        name: "Ana Rivera",
         group: "2º A",
-        caseState: CaseState.PATRON_DETECTADO,
-        incidents: [{}, {}, {}],
-        matricula: "MAT-001",
+        matricula: "2024-1001",
+        caseState: "PATRON_DETECTADO",
+        puntajeRiesgo: 72,
+        estadoSemaforo: "AMARILLO",
       },
-      {
-        id: "2",
-        name: "Intervention Student",
-        group: "3º B",
-        caseState: CaseState.INTERVENCION,
-        incidents: [{}, {}, {}, {}, {}],
-        matricula: "MAT-002",
-      }
     ],
-    setCurrentModule: mocks.setCurrentModule,
-    setQuickRegisterOpen: vi.fn(),
-    addIncident: mocks.addIncident,
   }),
 }));
 
 vi.mock("../src/components/AuthProvider", () => ({
   useAuth: () => ({
-    user: { id: "user-1", email: "test@sase.com" },
+    user: { id: "user-1", email: "orientacion@sase.mx" },
   }),
 }));
 
-const supabaseMocks = vi.hoisted(() => ({
-  from: vi.fn(),
-  select: vi.fn(),
-  ilike: vi.fn(),
-  single: vi.fn(),
-  insert: vi.fn(),
+vi.mock("react-hot-toast", () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
-vi.mock("../src/supabase/client", () => {
-  supabaseMocks.ilike.mockReturnValue({ single: supabaseMocks.single });
-  supabaseMocks.single.mockResolvedValue({ data: null, error: null });
-  supabaseMocks.select.mockReturnValue({ ilike: supabaseMocks.ilike });
-  supabaseMocks.insert.mockResolvedValue({ error: null });
-  supabaseMocks.from.mockReturnValue({
-    select: supabaseMocks.select,
-    insert: supabaseMocks.insert,
-  });
-
-  return {
-    supabase: {
-      from: supabaseMocks.from,
-    },
-  };
-});
-
-// Robust Toast Mock
-vi.mock("react-hot-toast", () => {
-  const toast: any = vi.fn();
-  toast.success = vi.fn();
-  toast.error = vi.fn();
-  toast.loading = vi.fn();
-  return { default: toast };
-});
-
-describe("Dashboard Orientacion Hardening Tests", () => {
+describe("Dashboard Orientacion v2", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.print.mockReset();
+    Object.defineProperty(window, "print", {
+      value: mocks.print,
+      writable: true,
+    });
+
+    mocks.loadCases.mockResolvedValue([
+      {
+        id: "case-1",
+        alumnoId: "student-1",
+        alumnoNombre: "Ana Rivera",
+        grupo: "2º A",
+        matricula: "2024-1001",
+        estado: "en_analisis",
+        prioridad: "alta",
+        motivo: "Acompañamiento por alertas de conducta",
+        resumen: "Caso institucional abierto",
+        fechaApertura: "2026-05-01T00:00:00Z",
+        fechaActualizacion: "2026-05-01T00:00:00Z",
+        responsableId: "user-1",
+      },
+    ]);
+
+    mocks.loadDocentes.mockResolvedValue([
+      { id: "doc-1", nombreCompleto: "Mtro. López", rol: "docente" },
+    ]);
+
+    mocks.loadHistory.mockResolvedValue({
+      summary: { total_incidencias: 3, total_justificantes: 1 },
+      incidents: [{ id: "i-1", fecha: "2026-05-01", titulo: "Retardo", detalle: "Llegó tarde", fuente: "Incidencias" }],
+      citations: [],
+      contacts: [],
+      interventions: [],
+      teacherReports: [],
+      plans: [],
+      requests: [],
+      followUps: [],
+    });
+
+    mocks.openCase.mockResolvedValue("case-new");
+    mocks.requestDiagnosis.mockResolvedValue("request-1");
+    mocks.createPlan.mockResolvedValue("plan-1");
+    mocks.deriveSocialWork.mockResolvedValue(undefined);
+    mocks.escalateDirection.mockResolvedValue(undefined);
   });
 
-  it("renders Header correctly with institutional branding", () => {
+  it("renderiza el encabezado institucional y la bandeja", async () => {
     render(<DashboardOrientacion />);
-    expect(screen.getByText(/Orientacion Educativa/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Acompañamiento socioemocional/i),
-    ).toBeInTheDocument();
+
+    expect(screen.getByRole("heading", { name: /Casos, diagnósticos y evidencia institucional/i })).toBeInTheDocument();
+    expect(screen.getByText(/Bandeja persistente/i)).toBeInTheDocument();
+
+    await screen.findByRole("heading", { name: "Ana Rivera" });
+    expect(screen.getByText(/Bandeja de casos/i)).toBeInTheDocument();
+    expect(screen.getByText(/Historial institucional/i)).toBeInTheDocument();
   });
 
-  it("Displays Pattern Alert for PATRON_DETECTADO state", () => {
-    render(<DashboardOrientacion />);
-    expect(screen.getByText("Pattern Student")).toBeInTheDocument();
-  });
-
-  it("Identifies Intervention Priority for INTERVENCION state", () => {
-    render(<DashboardOrientacion />);
-    expect(screen.getByText("Intervention Student")).toBeInTheDocument();
-    // Verification of institutional label (CaseLabels mapping)
-    expect(screen.getAllByText(/Acompañamiento Intensivo/i)[0]).toBeInTheDocument();
-  });
-
-  it("Print Report opens institutional BIP document", async () => {
+  it("abre un caso sugerido y solicita diagnóstico", async () => {
     render(<DashboardOrientacion />);
 
-    const printBtn = screen.getByText(/Generar bitácora institucional/i);
-    fireEvent.click(printBtn);
+    await screen.findByRole("heading", { name: "Ana Rivera" });
 
-    expect(
-      await screen.findByText(/BITÁCORA DE INTERVENCIÓN PSICOPEDAGÓGICA/i),
-    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /abrir caso/i }));
+    await waitFor(() => expect(mocks.openCase).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole("button", { name: /enviar solicitud/i }));
+    await waitFor(() => expect(mocks.requestDiagnosis).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
Módulo Orientación v2 con backend base y UI analítica.

Incluye:
- Apertura de caso de orientación
- Solicitud y recepción de diagnósticos docentes
- Historial institucional del alumno (incidencias + reportes)
- Plan de intervención (definición, responsables, fechas)
- Derivación a Trabajo Social y escalamiento a Dirección
- Vista de reporte imprimible

Backend:
- Reutilización de tablas existentes donde aplica
- Nuevas estructuras mínimas (si no existían): orientacion_casos, solicitudes_diagnostico, diagnosticos_docentes, planes_intervencion, seguimiento_orientacion
- Políticas RLS por rol (orientación, docente, TS, dirección)
- Sin uso de service_role en frontend

Frontend:
- Dashboard mobile-first (badge ORIENTACIÓN, púrpura)
- Bandeja de casos, detalle, solicitudes, plan y seguimiento

Validación:
- pnpm install --frozen-lockfile OK
- type-check OK
- build OK
- tests OK (33/33)

Notas:
- No modifica autenticación
- No rompe RLS existente; se extiende de forma mínima