### PR TITLE
fix: add missing grants and trigger for orientacion v2

### DIFF
--- a/supabase/migrations/20260506051327_hotfix_orientacion_v2_grants_and_trigger.sql
+++ b/supabase/migrations/20260506051327_hotfix_orientacion_v2_grants_and_trigger.sql
@@ -1,0 +1,38 @@
+-- 1. Trigger function to update solicitud state
+CREATE OR REPLACE FUNCTION public.fn_marcar_solicitud_respondida()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  UPDATE public.solicitudes_diagnostico
+  SET
+    estado = 'respondido',
+    fecha_respuesta = now()
+  WHERE id = NEW.solicitud_id;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS tr_marcar_solicitud_respondida ON public.diagnosticos_docentes;
+
+CREATE TRIGGER tr_marcar_solicitud_respondida
+AFTER INSERT ON public.diagnosticos_docentes
+FOR EACH ROW
+EXECUTE FUNCTION public.fn_marcar_solicitud_respondida();
+
+-- 2. Grants for RPCs
+GRANT EXECUTE ON FUNCTION public.abrir_caso_orientacion(uuid, text, text, text, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.solicitar_diagnostico(uuid, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.registrar_diagnostico(uuid, text, text, text, text, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.crear_plan_intervencion(uuid, text, text, text, date, date, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.derivar_trabajo_social(uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.escalar_direccion(uuid, text) TO authenticated;
+
+-- 3. Grants for Tables (to allow SECURITY INVOKER functions to work properly)
+GRANT SELECT, INSERT, UPDATE ON TABLE public.orientacion_casos TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.solicitudes_diagnostico TO authenticated;
+GRANT SELECT, INSERT ON TABLE public.diagnosticos_docentes TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.planes_intervencion TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.seguimiento_orientacion TO authenticated;


### PR DESCRIPTION
Hotfix remoto:
- Trigger para marcar solicitud_diagnostico como 'respondido'
- Grants de ejecución en RPCs de Orientación
- Grants sobre tablas para permitir Security Invoker functions

No se han tocado otros módulos.