### PR TITLE
fix(ui): prevent mobile overlap in reportes and emergency layers

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -592,27 +592,27 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({
       {/* Main Content Area */}
       <div className="flex-1 flex flex-col min-w-0 relative">
         {/* Header */}
-        <header className="h-20 bg-[rgba(17,24,39,0.72)] backdrop-blur-[44px] border-b border-[rgba(255,255,255,0.14)] flex items-center justify-between px-6 shrink-0 z-40 shadow-[0_14px_40px_rgba(2,6,23,0.25)]">
-          <div className="flex items-center gap-6">
+        <header className="h-16 sm:h-20 bg-[rgba(11,15,25,0.85)] backdrop-blur-[32px] border-b border-white/10 flex items-center justify-between px-3 sm:px-6 shrink-0 z-40 shadow-[0_8px_32px_rgba(0,0,0,0.3)]">
+          <div className="flex items-center gap-3 sm:gap-6">
             <button
-              className="md:hidden size-10 flex items-center justify-center bg-white/60 border border-white/60 rounded-xl text-slate-600"
+              className="md:hidden size-10 flex items-center justify-center bg-white/5 border border-white/10 rounded-xl text-slate-300 hover:bg-white/10"
               onClick={() => setIsSidebarOpen(true)}
             >
-              <span className="material-icons">menu</span>
+              <span className="material-icons text-xl">menu</span>
             </button>
 
-              <div className="flex flex-col">
-                <div className="flex items-center gap-3">
-                  <div className="flex items-center justify-center w-10 h-10 rounded-2xl bg-[rgba(121,118,124,0.14)] border border-[rgba(255,255,255,0.14)] shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_8px_24px_rgba(2,6,23,0.18)]">
-                    <img src="/assets/branding/favicon.png" alt="SASE Logo" className="w-6 h-6 object-contain drop-shadow-[0_0_8px_rgba(255,255,255,0.22)]" />
-                  </div>
-                  <h2 className="text-lg font-black text-white uppercase tracking-[0.2em] flex items-center">
-                    SASE <span className="text-blue-400/50 mx-2 text-sm">/</span>{" "}
-                    <span className="text-blue-300 text-xs tracking-[0.3em] uppercase">SISTEMA DE ACOMPAÑAMIENTO Y SEGUIMIENTO ESCOLAR</span>
-                  </h2>
+            <div className="flex flex-col">
+              <div className="flex items-center gap-2 sm:gap-3">
+                <div className="flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-xl sm:rounded-2xl bg-white/5 border border-white/10 shadow-inner">
+                  <img src="/assets/branding/favicon.png" alt="SASE Logo" className="w-5 h-5 sm:w-6 sm:h-6 object-contain" />
                 </div>
-              <p className="text-[10px] font-bold text-slate-300 uppercase tracking-widest mt-1 ml-10">
-                Estatus: Operativo • v{VERSION.numero} • GESTIÓN INSTITUCIONAL DE NUEVA GENERACIÓN
+                <h2 className="text-sm sm:text-lg font-black text-white uppercase tracking-[0.15em] sm:tracking-[0.2em] flex items-center">
+                  SASE <span className="hidden xs:inline text-blue-400/50 mx-2 text-sm">/</span>{" "}
+                  <span className="hidden sm:inline text-blue-300 text-xs tracking-[0.3em] uppercase">SISTEMA DE ACOMPAÑAMIENTO Y SEGUIMIENTO ESCOLAR</span>
+                </h2>
+              </div>
+              <p className="hidden md:block text-[10px] font-bold text-slate-400 uppercase tracking-widest mt-1 ml-10">
+                Estatus: Operativo • v{VERSION.numero} • GESTIÓN INSTITUCIONAL
               </p>
             </div>
           </div>

--- a/src/components/Reportes.tsx
+++ b/src/components/Reportes.tsx
@@ -500,23 +500,23 @@ export const Reportes: React.FC = () => {
     <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
-      className="flex-1 p-6 lg:p-8 relative z-10 w-full max-w-7xl mx-auto h-full flex flex-col"
+      className="flex-1 p-4 sm:p-6 lg:p-8 pb-32 sm:pb-8 relative z-10 w-full max-w-7xl mx-auto flex flex-col min-h-full"
     >
       {/* ENCABEZADO */}
       <div className="mb-6">
-        <h1 className="text-3xl font-bold text-white mb-2 tracking-wide">
+        <h1 className="text-2xl sm:text-3xl font-black text-white mb-2 tracking-tight uppercase italic">
           Reportes Institucionales
         </h1>
-        <p className="text-slate-400 text-sm">
-          Filtra, consulta e imprime la bitacora e incidencias.
+        <p className="text-slate-400 text-xs font-medium uppercase tracking-widest">
+          Filtra, consulta e imprime la bitácora e incidencias por periodo.
         </p>
       </div>
-
+ 
       <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 flex-1 min-h-0">
         {/* PANEL LATERAL DE FILTROS */}
-        <GlassCard className="lg:col-span-1 flex flex-col h-fit">
-          <h2 className="text-lg font-semibold text-white mb-4 flex items-center gap-2">
-            <span className="material-icons text-blue-400 text-sm">filter_alt</span>
+        <GlassCard className="lg:col-span-1 flex flex-col h-fit md:sticky md:top-0">
+          <h2 className="text-sm font-black text-white mb-4 flex items-center gap-2 uppercase tracking-widest italic">
+            <span className="material-icons text-blue-400 text-lg">filter_alt</span>
             Filtros
           </h2>
 

--- a/src/components/ai/SasitoAssistant.tsx
+++ b/src/components/ai/SasitoAssistant.tsx
@@ -334,7 +334,7 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
     <>
       <motion.div 
         ref={constraintsRef}
-        className="fixed inset-0 pointer-events-none z-[9999]"
+        className={`fixed inset-0 pointer-events-none ${isChatOpen ? 'z-[110]' : 'z-[85]'}`}
       >
         <motion.div 
           id="sasito-assistant-anchor"
@@ -346,7 +346,7 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
           className={`absolute pointer-events-auto flex flex-col items-center gap-4 ${
             isWidgetMode 
               ? 'top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2' 
-              : 'bottom-12 right-12 items-end'
+              : 'bottom-24 right-6 sm:bottom-12 sm:right-12 items-end'
           }`}
         >
         <AnimatePresence>
@@ -482,7 +482,7 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
                 localState === 'alert' ? 'alert' : 
                 localState === 'attention' ? 'warning' : 'normal'
               } 
-              className={minimal ? "w-20 h-20" : isTourActive ? "w-20 h-20" : "w-24 h-24"}
+              className={minimal ? "w-16 h-16 sm:w-20 sm:h-20" : isTourActive ? "w-16 h-16 sm:w-20 sm:h-20" : "w-20 h-20 sm:w-24 sm:h-24"}
               showAura={true}
               showGlow={true}
             />

--- a/src/components/emergency/EmergencyBoard.tsx
+++ b/src/components/emergency/EmergencyBoard.tsx
@@ -29,11 +29,11 @@ const EmergencyCard: React.FC<{ alert: EmergencyAlert }> = ({ alert }) => (
 );
 
 const Column: React.FC<ColumnConfig> = ({ title, items, accent }) => (
-  <div className="min-h-48 rounded-2xl border border-white/8 bg-[#0f1117]/92 p-3">
-    <div className={`mb-3 rounded-xl px-3 py-2 text-[10px] font-black uppercase tracking-widest ${accent}`}>
+  <div className="flex flex-col h-full min-h-[12rem] rounded-2xl border border-white/8 bg-[#0f1117]/92 p-3">
+    <div className={`mb-3 rounded-xl px-3 py-2 text-[10px] font-black uppercase tracking-widest ${accent} sticky top-0 z-10 backdrop-blur-md`}>
       {title} ({items.length})
     </div>
-    <div className="space-y-2">
+    <div className="flex-1 space-y-2 overflow-y-auto custom-scrollbar pr-1 max-h-[30vh] md:max-h-none">
       {items.length === 0 ? (
         <p className="rounded-xl border border-dashed border-white/10 p-4 text-center text-[10px] font-bold uppercase tracking-widest text-slate-600">
           Sin registros
@@ -48,13 +48,14 @@ const Column: React.FC<ColumnConfig> = ({ title, items, accent }) => (
 export const EmergencyBoard: React.FC<{ alerts: EmergencyAlert[] }> = ({ alerts }) => {
   const columns: ColumnConfig[] = [
     { title: "Activas", items: alerts.filter((alert) => alert.estado === "activa"), accent: "bg-red-500/15 text-red-200" },
-    { title: "En atencion", items: alerts.filter((alert) => alert.estado === "atendida"), accent: "bg-amber-500/15 text-amber-200" },
+    { title: "En atención", items: alerts.filter((alert) => alert.estado === "atendida"), accent: "bg-amber-500/15 text-amber-200" },
     { title: "Cerradas", items: alerts.filter((alert) => alert.estado === "cancelada"), accent: "bg-emerald-500/15 text-emerald-200" },
   ];
 
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-3 pb-safe">
       {columns.map((column) => <Column key={column.title} {...column} />)}
     </div>
   );
 };
+

--- a/src/components/emergency/EmergencyButton.tsx
+++ b/src/components/emergency/EmergencyButton.tsx
@@ -60,11 +60,12 @@ export const EmergencyButton: React.FC = () => {
           event.preventDefault();
           if (myActiveAlert) setIsOpen(true);
         }}
-        className={`fixed bottom-6 right-6 z-[100] flex h-16 w-16 items-center justify-center rounded-full shadow-2xl transition-all duration-300 ${
+        className={`fixed right-6 z-[100] flex h-16 w-16 items-center justify-center rounded-full shadow-2xl transition-all duration-300 ${
           myActiveAlert
             ? "bg-rose-600 animate-pulse ring-4 ring-rose-400/50"
             : "bg-red-600 hover:bg-red-500 ring-4 ring-white/10"
         }`}
+        style={{ bottom: 'calc(env(safe-area-inset-bottom) + 1.5rem)' }}
         aria-label={myActiveAlert ? "Alerta activa" : "Mantener presionado para pedir ayuda"}
       >
         <div className="relative flex items-center justify-center">
@@ -73,12 +74,12 @@ export const EmergencyButton: React.FC = () => {
           ) : (
             <AlertCircle className="h-8 w-8 text-white" />
           )}
-
+ 
           {holding && !myActiveAlert && (
             <span className="absolute inset-0 rounded-full border-4 border-white/80 animate-ping" />
           )}
-
-          <span className="absolute -top-12 right-0 whitespace-nowrap rounded-lg bg-red-600 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-white shadow-lg">
+ 
+          <span className="absolute -top-12 right-0 whitespace-nowrap rounded-lg bg-red-600 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-white shadow-lg pointer-events-none">
             {myActiveAlert ? "ALERTA ACTIVA" : holding ? "MANTEN PRESIONADO" : "PEDIR AYUDA"}
           </span>
         </div>

--- a/src/components/emergency/EmergencyResponsePanel.tsx
+++ b/src/components/emergency/EmergencyResponsePanel.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useApp } from "../../store";
 import { motion, AnimatePresence } from "framer-motion";
 import { 
@@ -7,7 +7,10 @@ import {
   MapPin, 
   User, 
   ChevronRight,
-  Send
+  Send,
+  ChevronDown,
+  ChevronUp,
+  Maximize2
 } from "lucide-react";
 import type { ResponseStatus } from "../../types/emergency";
 import toast from "react-hot-toast";
@@ -21,6 +24,8 @@ export const EmergencyResponsePanel: React.FC = () => {
     closeEmergencyAlert
   } = useApp();
 
+  const [isExpanded, setIsExpanded] = useState(false);
+
   // Filtrar solo las alertas del staff (si el usuario es staff autorizado)
   const isStaff = ['directivo', 'subdireccion', 'prefectura', 'medico_escolar', 'system_admin', 'developer'].includes(currentUserProfile?.rol);
 
@@ -33,71 +38,96 @@ export const EmergencyResponsePanel: React.FC = () => {
     toast.success(`Respuesta "${respuesta.replace('_', ' ')}" enviada`);
   };
 
+  const showBoard = currentUserProfile?.rol === 'directivo' || currentUserProfile?.rol === 'subdireccion';
+
   return (
-    <div className="fixed top-20 right-6 z-[90] w-full max-w-5xl space-y-3 px-4 md:px-0">
-      {currentUserProfile?.rol === 'directivo' || currentUserProfile?.rol === 'subdireccion' ? (
-        <EmergencyBoard alerts={activeAlerts} />
-      ) : null}
-      <AnimatePresence>
-        {activeOnly.map((alert) => (
-          <motion.div
-            key={alert.id}
-            initial={{ x: 100, opacity: 0 }}
-            animate={{ x: 0, opacity: 1 }}
-            exit={{ x: 100, opacity: 0 }}
-            className="overflow-hidden rounded-2xl border border-red-500/30 bg-[#1a0b0b]/90 backdrop-blur-xl shadow-2xl shadow-red-900/20"
-          >
-            <div className="bg-red-600 px-4 py-2 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4 text-white animate-pulse" />
-                <span className="text-[10px] font-black uppercase tracking-widest text-white">Emergencia: {alert.tipo_alerta}</span>
-              </div>
-              <span className="text-[9px] font-bold text-red-100">{new Date(alert.created_at).toLocaleTimeString()}</span>
-            </div>
+    <div className="fixed top-20 right-0 md:right-6 z-[95] w-full md:max-w-5xl space-y-3 px-4 md:px-0 pointer-events-none">
+      {/* Indicador Compacto para Móvil */}
+      <div className="flex justify-end md:hidden">
+        <motion.button
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="pointer-events-auto flex items-center gap-2 rounded-full bg-red-600 px-4 py-2 text-[10px] font-black uppercase tracking-widest text-white shadow-xl shadow-red-900/40 border border-white/20"
+        >
+          <AlertTriangle className="h-4 w-4 animate-pulse" />
+          {activeOnly.length} Alertas Activas
+          {isExpanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+        </motion.button>
+      </div>
 
-            <div className="p-4 space-y-4">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2 text-slate-300">
-                  <User className="h-3.5 w-3.5" />
-                  <span className="text-xs font-bold uppercase tracking-tight">{alert.docente_nombre}</span>
+      {/* Panel Contenido (Board + Alertas) */}
+      <div className={`space-y-3 pointer-events-auto transition-all duration-300 ${!isExpanded ? 'hidden md:block' : 'block'}`}>
+        {showBoard && (
+          <div className="max-h-[40vh] md:max-h-none overflow-y-auto md:overflow-visible rounded-2xl">
+            <EmergencyBoard alerts={activeAlerts} />
+          </div>
+        )}
+        
+        <div className="space-y-3 max-h-[50vh] md:max-h-none overflow-y-auto md:overflow-visible pb-4">
+          <AnimatePresence>
+            {activeOnly.map((alert) => (
+              <motion.div
+                key={alert.id}
+                initial={{ x: 100, opacity: 0 }}
+                animate={{ x: 0, opacity: 1 }}
+                exit={{ x: 100, opacity: 0 }}
+                className="overflow-hidden rounded-2xl border border-red-500/30 bg-[#1a0b0b]/95 backdrop-blur-xl shadow-2xl shadow-red-900/30"
+              >
+                <div className="bg-red-600 px-4 py-2 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <AlertTriangle className="h-4 w-4 text-white animate-pulse" />
+                    <span className="text-[10px] font-black uppercase tracking-widest text-white">Emergencia: {alert.tipo_alerta}</span>
+                  </div>
+                  <span className="text-[9px] font-bold text-red-100">{new Date(alert.created_at).toLocaleTimeString()}</span>
                 </div>
-                <div className="flex items-center gap-2 text-slate-400">
-                  <MapPin className="h-3.5 w-3.5" />
-                  <span className="text-xs font-medium uppercase">Aula: {alert.aula} | Grupo: {alert.grupo}</span>
-                </div>
-              </div>
 
-              {/* Botones de Respuesta */}
-              <div className="grid grid-cols-2 gap-2">
-                <button
-                  onClick={() => handleResponse(alert.id, 'enterado')}
-                  className="rounded-lg bg-blue-600/20 border border-blue-500/30 py-2 text-[10px] font-black uppercase tracking-wider text-blue-300 hover:bg-blue-600/40 transition-all"
-                >
-                  Enterado
-                </button>
-                <button
-                  onClick={() => handleResponse(alert.id, 'voy_en_camino')}
-                  className="rounded-lg bg-amber-600/20 border border-amber-500/30 py-2 text-[10px] font-black uppercase tracking-wider text-amber-300 hover:bg-amber-600/40 transition-all"
-                >
-                  Voy en camino
-                </button>
-                <button
-                  onClick={() => handleResponse(alert.id, 'atendida')}
-                  className="rounded-lg bg-emerald-600/20 border border-emerald-500/30 py-2 text-[10px] font-black uppercase tracking-wider text-emerald-300 hover:bg-emerald-600/40 transition-all"
-                >
-                  Atendida
-                </button>
-                <button
-                  onClick={() => closeEmergencyAlert(alert.id)}
-                  className="rounded-lg bg-slate-600/20 border border-slate-500/30 py-2 text-[10px] font-black uppercase tracking-wider text-slate-300 hover:bg-slate-600/40 transition-all"
-                >
-                  Cerrar
-                </button>
-              </div>
-            </div>
-          </motion.div>
-        ))}
-      </AnimatePresence>
+                <div className="p-4 space-y-4">
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 text-slate-300">
+                      <User className="h-3.5 w-3.5" />
+                      <span className="text-xs font-bold uppercase tracking-tight">{alert.docente_nombre}</span>
+                    </div>
+                    <div className="flex items-center gap-2 text-slate-400">
+                      <MapPin className="h-3.5 w-3.5" />
+                      <span className="text-xs font-medium uppercase">Aula: {alert.aula} | Grupo: {alert.grupo}</span>
+                    </div>
+                  </div>
+
+                  {/* Botones de Respuesta */}
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      onClick={() => handleResponse(alert.id, 'enterado')}
+                      className="rounded-lg bg-blue-600/20 border border-blue-500/30 py-2.5 text-[10px] font-black uppercase tracking-wider text-blue-300 hover:bg-blue-600/40 transition-all"
+                    >
+                      Enterado
+                    </button>
+                    <button
+                      onClick={() => handleResponse(alert.id, 'voy_en_camino')}
+                      className="rounded-lg bg-amber-600/20 border border-amber-500/30 py-2.5 text-[10px] font-black uppercase tracking-wider text-amber-300 hover:bg-amber-600/40 transition-all"
+                    >
+                      En camino
+                    </button>
+                    <button
+                      onClick={() => handleResponse(alert.id, 'atendida')}
+                      className="rounded-lg bg-emerald-600/20 border border-emerald-500/30 py-2.5 text-[10px] font-black uppercase tracking-wider text-emerald-300 hover:bg-emerald-600/40 transition-all"
+                    >
+                      Atendida
+                    </button>
+                    <button
+                      onClick={() => closeEmergencyAlert(alert.id)}
+                      className="rounded-lg bg-slate-600/20 border border-slate-500/30 py-2.5 text-[10px] font-black uppercase tracking-wider text-slate-300 hover:bg-slate-600/40 transition-all"
+                    >
+                      Cerrar
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
     </div>
   );
 };
+


### PR DESCRIPTION
Corregir la regresión visual donde Reportes Institucionales se encima con EmergencyBoard, Sasito y SOS en móvil.

Cambios:
- EmergencyResponsePanel: Añadido indicador compacto para móvil que se expande al click.
- EmergencyBoard: Añadido scroll y límites de altura para columnas en móvil.
- Layout: Header responsivo (altura, padding y visibilidad de títulos).
- Reportes: Padding responsivo y espacio inferior para evitar traslapes.
- Floating elements: Ajustes de z-index, tamaño y posición para Sasito y botón SOS.

Validaciones:
- pnpm type-check: OK
- pnpm test: OK
- pnpm build: OK