### PR TITLE
fix: harden Feria role handoff mapping

### DIFF
--- a/src/components/ai/sasito/sasitoActionCatalog.ts
+++ b/src/components/ai/sasito/sasitoActionCatalog.ts
@@ -1,0 +1,147 @@
+import { AppModule, UserRole } from "../../../types";
+import { tienePermiso } from "../../../utils/permisos";
+import type { SasitoActionDefinition, SasitoIntent, SasitoIntentResult, SasitoRuntimeContext } from "./types";
+
+const STAFF_ROLES = [
+  UserRole.DIRECTIVO,
+  UserRole.SUBDIRECCION,
+  UserRole.DOCENTE,
+  UserRole.DOCENTE_TUTOR,
+  UserRole.PREFECTURA,
+  UserRole.ORIENTACION,
+  UserRole.TRABAJO_SOCIAL,
+  UserRole.MEDICO_ESCOLAR,
+  UserRole.UDEII,
+  UserRole.PROMOTORA_LECTURA,
+  UserRole.SECRETARIA,
+  UserRole.DEVELOPER,
+  UserRole.SYSTEM_ADMIN,
+];
+
+const ACTION_CATALOG: Record<SasitoIntent, SasitoActionDefinition> = {
+  open_quick_register: {
+    id: "open_quick_register",
+    intent: "open_quick_register",
+    label: "Abrir Registro Rapido",
+    requiredPermission: "can_register",
+    allowedRoles: STAFF_ROLES,
+    executionType: "open_modal",
+    safetyMessage: "Tu rol no tiene autorizado abrir Registro Rapido desde Sasito.",
+    requiresConfirmation: false,
+  },
+  search_student: {
+    id: "search_student",
+    intent: "search_student",
+    label: "Buscar alumno",
+    requiredPermission: "can_view_names",
+    allowedRoles: STAFF_ROLES,
+    executionType: "show_card",
+    safetyMessage: "Tu rol no tiene autorizado buscar alumnos desde Sasito.",
+  },
+  open_student_record: {
+    id: "open_student_record",
+    intent: "open_student_record",
+    label: "Abrir expediente",
+    requiredPermission: "can_view_names",
+    allowedRoles: [UserRole.DIRECTIVO, UserRole.SUBDIRECCION, UserRole.ORIENTACION, UserRole.TRABAJO_SOCIAL, UserRole.SECRETARIA, UserRole.DEVELOPER, UserRole.SYSTEM_ADMIN],
+    moduleTarget: AppModule.EXPEDIENTES,
+    executionType: "navigate",
+    safetyMessage: "Tu rol no tiene autorizado abrir expedientes desde Sasito.",
+  },
+  open_health_module: {
+    id: "open_health_module",
+    intent: "open_health_module",
+    label: "Abrir modulo de salud",
+    requiredPermission: "can_view_sensitive",
+    allowedRoles: [UserRole.DIRECTIVO, UserRole.SUBDIRECCION, UserRole.ORIENTACION, UserRole.TRABAJO_SOCIAL, UserRole.MEDICO_ESCOLAR, UserRole.UDEII, UserRole.DEVELOPER, UserRole.SYSTEM_ADMIN],
+    moduleTarget: AppModule.SALUD,
+    executionType: "navigate",
+    safetyMessage: "Tu rol no tiene autorizado consultar Salud desde Sasito.",
+  },
+  open_orientation_cases: {
+    id: "open_orientation_cases",
+    intent: "open_orientation_cases",
+    label: "Abrir casos de Orientacion",
+    requiredPermission: "can_edit",
+    allowedRoles: [UserRole.DIRECTIVO, UserRole.SUBDIRECCION, UserRole.ORIENTACION, UserRole.TRABAJO_SOCIAL, UserRole.UDEII, UserRole.DEVELOPER, UserRole.SYSTEM_ADMIN],
+    moduleTarget: AppModule.REPORTES,
+    executionType: "navigate",
+    safetyMessage: "Tu rol no tiene autorizado abrir casos de Orientacion desde Sasito.",
+  },
+  open_collective_diagnosis: {
+    id: "open_collective_diagnosis",
+    intent: "open_collective_diagnosis",
+    label: "Abrir Diagnostico Colectivo",
+    requiredPermission: "can_register",
+    allowedRoles: [UserRole.DOCENTE, UserRole.DOCENTE_TUTOR, UserRole.DIRECTIVO, UserRole.SUBDIRECCION, UserRole.DEVELOPER, UserRole.SYSTEM_ADMIN],
+    moduleTarget: AppModule.DIAGNOSTICO,
+    executionType: "navigate",
+    safetyMessage: "Tu rol no tiene autorizado abrir Diagnostico Colectivo desde Sasito.",
+  },
+  show_notifications: {
+    id: "show_notifications",
+    intent: "show_notifications",
+    label: "Mostrar notificaciones",
+    requiredPermission: null,
+    allowedRoles: Object.values(UserRole),
+    moduleTarget: AppModule.NOTIFICATIONS,
+    executionType: "navigate",
+    safetyMessage: "No fue posible abrir notificaciones para este perfil.",
+  },
+  explain_next_step: {
+    id: "explain_next_step",
+    intent: "explain_next_step",
+    label: "Explicar siguiente paso",
+    requiredPermission: null,
+    allowedRoles: STAFF_ROLES,
+    executionType: "suggest_only",
+    safetyMessage: "Selecciona primero un caso o alumno para recibir una recomendacion institucional segura.",
+  },
+  unknown: {
+    id: "unknown",
+    intent: "unknown",
+    label: "Intencion no reconocida",
+    requiredPermission: null,
+    allowedRoles: Object.values(UserRole),
+    executionType: "deny",
+    safetyMessage: "No tengo esa accion configurada de forma segura.",
+  },
+};
+
+const denyAction = (action: SasitoActionDefinition): SasitoActionDefinition => ({
+  ...action,
+  moduleTarget: undefined,
+  executionType: "deny",
+  requiresConfirmation: false,
+});
+
+export function getSasitoActionDefinition(intent: SasitoIntent): SasitoActionDefinition {
+  return ACTION_CATALOG[intent] || ACTION_CATALOG.unknown;
+}
+
+export function resolveSasitoAction(
+  intentResult: SasitoIntentResult,
+  context: SasitoRuntimeContext,
+): SasitoActionDefinition {
+  const action = getSasitoActionDefinition(intentResult.intent);
+
+  if (action.executionType === "deny") return action;
+
+  if (!action.allowedRoles.includes(context.currentUserRole)) {
+    return denyAction(action);
+  }
+
+  if (action.requiredPermission && !tienePermiso(context.permissions, action.requiredPermission)) {
+    return denyAction(action);
+  }
+
+  if (action.intent === "explain_next_step" && !context.selectedCase) {
+    return {
+      ...action,
+      executionType: "suggest_only",
+      safetyMessage: "Selecciona un caso institucional antes de pedir el siguiente paso.",
+    };
+  }
+
+  return action;
+}

--- a/src/components/ai/sasito/sasitoContextProvider.ts
+++ b/src/components/ai/sasito/sasitoContextProvider.ts
@@ -1,0 +1,48 @@
+import { AppModule, UserRole } from "../../../types";
+import type { Student } from "../../../types";
+import { PERMISOS_POR_ROL, type PermisosSASE } from "../../../utils/permisos";
+import type { SystemState } from "../../../types/systemState";
+import type { SasitoRuntimeContext, SasitoSelectedCase, SasitoSelectedStudent } from "./types";
+
+interface SasitoContextSource {
+  currentUserRole?: UserRole;
+  currentUserProfile?: unknown | null;
+  currentModule?: AppModule;
+  currentRouteHash?: string;
+  selectedStudent?: SasitoSelectedStudent | null;
+  selectedGroup?: string | null;
+  selectedCase?: SasitoSelectedCase | null;
+  notifications?: unknown[];
+  students?: Student[];
+  aiSystemState?: SystemState;
+  permissions?: PermisosSASE;
+}
+
+const resolvePermissions = (role: UserRole, permissions?: PermisosSASE): PermisosSASE => {
+  if (permissions) return permissions;
+  return PERMISOS_POR_ROL[role] || PERMISOS_POR_ROL.guest;
+};
+
+const getCurrentRouteHash = (provided?: string) => {
+  if (provided) return provided;
+  if (typeof window === "undefined") return "";
+  return window.location.hash || "";
+};
+
+export function buildSasitoContext(source: SasitoContextSource): SasitoRuntimeContext {
+  const role = source.currentUserRole || UserRole.GUEST;
+
+  return {
+    currentUserRole: role,
+    currentUserProfile: source.currentUserProfile ?? null,
+    currentModule: source.currentModule || AppModule.HOME,
+    currentRouteHash: getCurrentRouteHash(source.currentRouteHash),
+    selectedStudent: source.selectedStudent ?? null,
+    selectedGroup: source.selectedGroup ?? null,
+    selectedCase: source.selectedCase ?? null,
+    notifications: source.notifications || [],
+    students: source.students || [],
+    aiSystemState: source.aiSystemState || "normal",
+    permissions: resolvePermissions(role, source.permissions),
+  };
+}

--- a/src/components/ai/sasito/sasitoIntentEngine.ts
+++ b/src/components/ai/sasito/sasitoIntentEngine.ts
@@ -1,0 +1,92 @@
+import { AppModule } from "../../../types";
+import type { Student } from "../../../types";
+import type { SasitoEntities, SasitoIntent, SasitoIntentResult, SasitoRuntimeContext } from "./types";
+
+interface SasitoIntentInput {
+  text: string;
+  context: SasitoRuntimeContext;
+}
+
+const normalizeText = (value: string) =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim();
+
+const hasAny = (normalizedText: string, keywords: string[]) =>
+  keywords.some((keyword) => normalizedText.includes(normalizeText(keyword)));
+
+const findStudentMention = (text: string, students: Student[]): SasitoEntities => {
+  const normalizedText = normalizeText(text);
+  const match = students.find((student) => {
+    const normalizedName = normalizeText(student.name || "");
+    return normalizedName.length > 2 && normalizedText.includes(normalizedName);
+  });
+
+  if (!match) return {};
+
+  return {
+    studentId: match.id,
+    studentName: match.name,
+    group: match.group,
+    rawMatches: [match.name],
+  };
+};
+
+const result = (
+  intent: SasitoIntent,
+  confidence: number,
+  reason: string,
+  entities: SasitoEntities = {},
+  moduleTarget?: AppModule,
+): SasitoIntentResult => ({
+  intent,
+  confidence,
+  entities,
+  moduleTarget,
+  reason,
+});
+
+export function detectSasitoIntent({ text, context }: SasitoIntentInput): SasitoIntentResult {
+  const normalized = normalizeText(text);
+  const studentEntities = findStudentMention(text, context.students || []);
+
+  if (!normalized) {
+    return result("unknown", 0, "No hay texto para clasificar.");
+  }
+
+  if (hasAny(normalized, ["reporte rapido", "registro rapido", "registrar incidencia", "crear incidencia", "levantar reporte", "reportar alumno"])) {
+    return result("open_quick_register", 0.92, "El usuario solicita registrar una incidencia o reporte rapido.");
+  }
+
+  if (hasAny(normalized, ["diagnostico colectivo", "diagnostico de grupo", "diagnostico grupal", "reporte colectivo"])) {
+    return result("open_collective_diagnosis", 0.9, "El usuario solicita abrir Diagnostico Colectivo.", {}, AppModule.DIAGNOSTICO);
+  }
+
+  if (hasAny(normalized, ["que sigue", "siguiente paso", "que hago", "como procedo", "proxima accion"])) {
+    return result("explain_next_step", 0.88, "El usuario pide orientacion operativa sobre el siguiente paso.");
+  }
+
+  if (hasAny(normalized, ["salud", "medico", "enfermeria", "alergia", "padecimiento", "medicamento"])) {
+    return result("open_health_module", 0.86, "El usuario solicita informacion o modulo de salud.", studentEntities, AppModule.SALUD);
+  }
+
+  if (hasAny(normalized, ["orientacion", "casos de orientacion", "socioemocional", "canalizacion", "seguimiento psicopedagogico"])) {
+    return result("open_orientation_cases", 0.84, "El usuario solicita casos de Orientacion.", studentEntities, AppModule.REPORTES);
+  }
+
+  if (hasAny(normalized, ["expediente", "historial", "archivo del alumno", "record del alumno", "antecedentes"])) {
+    return result("open_student_record", 0.84, "El usuario solicita abrir o consultar expediente.", studentEntities, AppModule.EXPEDIENTES);
+  }
+
+  if (hasAny(normalized, ["notificaciones", "avisos", "campana", "pendientes por leer"])) {
+    return result("show_notifications", 0.86, "El usuario solicita revisar notificaciones.", {}, AppModule.NOTIFICATIONS);
+  }
+
+  if (hasAny(normalized, ["buscar alumno", "busca a", "encuentra a", "localiza a", "donde esta"]) || studentEntities.studentId) {
+    return result("search_student", 0.78, "El usuario solicita busqueda de alumno.", studentEntities);
+  }
+
+  return result("unknown", 0.2, "No se encontro una intencion institucional segura.");
+}

--- a/src/components/ai/sasito/types.ts
+++ b/src/components/ai/sasito/types.ts
@@ -1,0 +1,77 @@
+import type { AppModule, Student, UserRole } from "../../../types";
+import type { PermisosSASE } from "../../../utils/permisos";
+import type { SystemState } from "../../../types/systemState";
+
+export type SasitoIntent =
+  | "open_quick_register"
+  | "search_student"
+  | "open_student_record"
+  | "open_health_module"
+  | "open_orientation_cases"
+  | "open_collective_diagnosis"
+  | "show_notifications"
+  | "explain_next_step"
+  | "unknown";
+
+export type SasitoExecutionType =
+  | "navigate"
+  | "open_modal"
+  | "show_card"
+  | "suggest_only"
+  | "deny";
+
+export interface SasitoEntities {
+  studentId?: string;
+  studentName?: string;
+  group?: string;
+  caseId?: string;
+  moduleKeyword?: string;
+  rawMatches?: string[];
+}
+
+export interface SasitoIntentResult {
+  intent: SasitoIntent;
+  confidence: number;
+  entities: SasitoEntities;
+  moduleTarget?: AppModule;
+  reason: string;
+}
+
+export interface SasitoSelectedStudent {
+  id: string;
+  name: string;
+  group?: string;
+}
+
+export interface SasitoSelectedCase {
+  id: string;
+  studentId?: string;
+  studentName?: string;
+  status?: string;
+}
+
+export interface SasitoRuntimeContext {
+  currentUserRole: UserRole;
+  currentUserProfile: unknown | null;
+  currentModule: AppModule;
+  currentRouteHash: string;
+  selectedStudent?: SasitoSelectedStudent | null;
+  selectedGroup?: string | null;
+  selectedCase?: SasitoSelectedCase | null;
+  notifications: unknown[];
+  students: Student[];
+  aiSystemState: SystemState;
+  permissions: PermisosSASE;
+}
+
+export interface SasitoActionDefinition {
+  id: string;
+  intent: SasitoIntent;
+  label: string;
+  requiredPermission: keyof PermisosSASE | null;
+  allowedRoles: UserRole[];
+  moduleTarget?: AppModule;
+  executionType: SasitoExecutionType;
+  safetyMessage: string;
+  requiresConfirmation?: boolean;
+}

--- a/tests/SasitoLevel3Base.test.ts
+++ b/tests/SasitoLevel3Base.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { AppModule, UserRole } from "../src/types";
+import { detectSasitoIntent } from "../src/components/ai/sasito/sasitoIntentEngine";
+import { resolveSasitoAction } from "../src/components/ai/sasito/sasitoActionCatalog";
+import { buildSasitoContext } from "../src/components/ai/sasito/sasitoContextProvider";
+
+describe("Sasito Nivel 3 base", () => {
+  it("detecta registrar incidencia como open_quick_register", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
+    const result = detectSasitoIntent({ text: "Necesito registrar incidencia", context });
+
+    expect(result.intent).toBe("open_quick_register");
+    expect(result.confidence).toBeGreaterThan(0.8);
+  });
+
+  it("detecta diagnostico colectivo como open_collective_diagnosis", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
+    const result = detectSasitoIntent({ text: "Abrir diagnóstico colectivo", context });
+
+    expect(result.intent).toBe("open_collective_diagnosis");
+    expect(result.moduleTarget).toBe(AppModule.DIAGNOSTICO);
+  });
+
+  it("detecta que sigue como explain_next_step", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.ORIENTACION });
+    const result = detectSasitoIntent({ text: "¿Qué sigue con este caso?", context });
+
+    expect(result.intent).toBe("explain_next_step");
+  });
+
+  it("ALUMNO recibe deny para Registro Rapido", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.ALUMNO });
+    const intent = detectSasitoIntent({ text: "registrar incidencia", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.executionType).toBe("deny");
+    expect(action.moduleTarget).toBeUndefined();
+  });
+
+  it("GUEST recibe deny para Registro Rapido", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.GUEST });
+    const intent = detectSasitoIntent({ text: "registrar incidencia", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.executionType).toBe("deny");
+    expect(action.moduleTarget).toBeUndefined();
+  });
+
+  it("docente recibe open_modal para Registro Rapido", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
+    const intent = detectSasitoIntent({ text: "registrar incidencia", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.executionType).toBe("open_modal");
+    expect(action.id).toBe("open_quick_register");
+  });
+
+  it("accion no autorizada no navega ni abre modal", () => {
+    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
+    const intent = detectSasitoIntent({ text: "abrir modulo de salud", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.executionType).toBe("deny");
+    expect(action.executionType).not.toBe("navigate");
+    expect(action.executionType).not.toBe("open_modal");
+    expect(action.moduleTarget).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Corrige el mapeo de roles en el handoff seguro hacia Feria para evitar escalamiento de privilegios. El token ya no fuerza teacher; ahora respeta roles institucionales: alumno→student, docente→teacher, admin/directivo/developer/system_admin→admin, staff institucional→staff. Incluye tests/FeriaHardening.test.ts. Sin cambios en Supabase, RLS, migrations, Diagnóstico Colectivo ni Sasito.