### PR TITLE
feat: add safe Sasito level 3 bridge behind feature flag

### DIFF
--- a/src/components/ai/SasitoAssistant.tsx
+++ b/src/components/ai/SasitoAssistant.tsx
@@ -5,6 +5,7 @@ import { useApp } from "../../store";
 import { UserRole, AppModule } from "../../types";
 import { SaseSplineOrb } from "../SaseSplineOrb";
 import toast from "react-hot-toast";
+import { trySasitoL3Bridge } from "./sasito/sasitoBridge";
 
 export type SasitoState = 'calm' | 'attention' | 'alert' | 'processing' | 'rebooting';
 
@@ -37,6 +38,7 @@ const ACTION_MODULES: Record<string, AppModule> = {
 export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidgetMode = false }) => {
   const {
     currentUserRole,
+    currentModule,
     setCurrentModule,
     setQuickRegisterOpen,
     setIsAssistantOpen,
@@ -265,6 +267,26 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
         setCurrentSuggestion({ 
           text: "El estado de INTERVENCIÓN es calculado exclusivamente por el Motor de Riesgo en PostgreSQL. No puedo alterarlo manualmente.", 
           state: 'attention' 
+        });
+        return;
+      }
+
+      const sasitoL3Response = trySasitoL3Bridge({
+        text,
+        currentUserRole: currentUserRole as UserRole,
+        currentUserProfile,
+        currentModule,
+        students,
+        notifications,
+        aiSystemState,
+      });
+
+      if (sasitoL3Response) {
+        setLocalState(sasitoL3Response.state);
+        setCurrentSuggestion({
+          text: sasitoL3Response.text,
+          state: sasitoL3Response.state,
+          actionLabel: sasitoL3Response.actionLabel,
         });
         return;
       }

--- a/src/components/ai/sasito/sasitoBridge.ts
+++ b/src/components/ai/sasito/sasitoBridge.ts
@@ -1,0 +1,96 @@
+import { AppModule } from "../../../types";
+import { buildSasitoContext } from "./sasitoContextProvider";
+import { detectSasitoIntent } from "./sasitoIntentEngine";
+import { resolveSasitoAction } from "./sasitoActionCatalog";
+import type { SasitoActionDefinition, SasitoIntentResult } from "./types";
+
+type SasitoBridgeEnv = {
+  VITE_ENABLE_SASITO_L3?: string | boolean;
+};
+
+type SasitoBridgeInput = Parameters<typeof buildSasitoContext>[0] & {
+  text: string;
+  env?: SasitoBridgeEnv;
+};
+
+type SasitoBridgeState = "calm" | "attention" | "alert";
+
+export interface SasitoBridgeResponse {
+  handled: boolean;
+  safeMode: true;
+  didExecuteAction: false;
+  text: string;
+  state: SasitoBridgeState;
+  actionLabel: string;
+  intent: SasitoIntentResult;
+  action: SasitoActionDefinition;
+  debug: {
+    intent: SasitoIntentResult["intent"];
+    confidence: number;
+    executionType: SasitoActionDefinition["executionType"];
+    actionId: string;
+    moduleTarget?: AppModule;
+  };
+}
+
+export function isSasitoL3Enabled(env?: SasitoBridgeEnv): boolean {
+  const value = env?.VITE_ENABLE_SASITO_L3 ?? import.meta.env.VITE_ENABLE_SASITO_L3;
+  return value === true || value === "true";
+}
+
+const getAllowedActionText = (action: SasitoActionDefinition): string => {
+  switch (action.executionType) {
+    case "open_modal":
+      return `Puedo ayudarte a ${action.label}. En esta fase segura no abrire modales automaticamente.`;
+    case "navigate":
+      return `Puedo ayudarte a ${action.label}. En esta fase segura no navegare automaticamente.`;
+    case "show_card":
+      return `Puedo ayudarte a ${action.label}. En esta fase segura solo te doy la guia textual.`;
+    case "suggest_only":
+      if (action.intent === "explain_next_step") {
+        return action.safetyMessage;
+      }
+      return `Sugerencia segura: ${action.label}.`;
+    case "deny":
+      return action.safetyMessage;
+    default:
+      return "Tengo una sugerencia segura, pero no ejecutare acciones automaticamente.";
+  }
+};
+
+const getResponseState = (action: SasitoActionDefinition): SasitoBridgeState => {
+  if (action.executionType === "deny") return "alert";
+  if (action.executionType === "suggest_only" || action.requiresConfirmation) return "attention";
+  return "calm";
+};
+
+export function createSasitoBridgeResponse(input: SasitoBridgeInput): SasitoBridgeResponse {
+  const context = buildSasitoContext(input);
+  const intent = detectSasitoIntent({ text: input.text, context });
+  const action = resolveSasitoAction(intent, context);
+  const handled = intent.intent !== "unknown";
+
+  return {
+    handled,
+    safeMode: true,
+    didExecuteAction: false,
+    text: getAllowedActionText(action),
+    state: getResponseState(action),
+    actionLabel: "ENTENDIDO",
+    intent,
+    action,
+    debug: {
+      intent: intent.intent,
+      confidence: intent.confidence,
+      executionType: action.executionType,
+      actionId: action.id,
+      moduleTarget: action.moduleTarget,
+    },
+  };
+}
+
+export function trySasitoL3Bridge(input: SasitoBridgeInput): SasitoBridgeResponse | null {
+  if (!isSasitoL3Enabled(input.env)) return null;
+
+  return createSasitoBridgeResponse(input);
+}

--- a/src/components/ai/sasito/sasitoIntentEngine.ts
+++ b/src/components/ai/sasito/sasitoIntentEngine.ts
@@ -56,7 +56,7 @@ export function detectSasitoIntent({ text, context }: SasitoIntentInput): Sasito
     return result("unknown", 0, "No hay texto para clasificar.");
   }
 
-  if (hasAny(normalized, ["reporte rapido", "registro rapido", "registrar incidencia", "crear incidencia", "levantar reporte", "reportar alumno"])) {
+  if (hasAny(normalized, ["reporte rapido", "registro rapido", "incidencia", "registrar incidencia", "crear incidencia", "levantar reporte", "reportar alumno"])) {
     return result("open_quick_register", 0.92, "El usuario solicita registrar una incidencia o reporte rapido.");
   }
 

--- a/tests/SasitoLevel3Base.test.ts
+++ b/tests/SasitoLevel3Base.test.ts
@@ -3,6 +3,7 @@ import { AppModule, UserRole } from "../src/types";
 import { detectSasitoIntent } from "../src/components/ai/sasito/sasitoIntentEngine";
 import { resolveSasitoAction } from "../src/components/ai/sasito/sasitoActionCatalog";
 import { buildSasitoContext } from "../src/components/ai/sasito/sasitoContextProvider";
+import { createSasitoBridgeResponse, isSasitoL3Enabled, trySasitoL3Bridge } from "../src/components/ai/sasito/sasitoBridge";
 
 describe("Sasito Nivel 3 base", () => {
   it("detecta registrar incidencia como open_quick_register", () => {
@@ -64,5 +65,115 @@ describe("Sasito Nivel 3 base", () => {
     expect(action.executionType).not.toBe("navigate");
     expect(action.executionType).not.toBe("open_modal");
     expect(action.moduleTarget).toBeUndefined();
+  });
+});
+
+describe("Sasito Nivel 3 bridge seguro", () => {
+  it("permanece apagado por defecto y deja intacto el flujo legado", () => {
+    expect(isSasitoL3Enabled({})).toBe(false);
+    expect(isSasitoL3Enabled({ VITE_ENABLE_SASITO_L3: "false" })).toBe(false);
+
+    const response = trySasitoL3Bridge({
+      text: "registrar incidencia",
+      currentUserRole: UserRole.DOCENTE,
+      env: { VITE_ENABLE_SASITO_L3: "false" },
+    });
+
+    expect(response).toBeNull();
+  });
+
+  it("con flag activa detecta Registro Rapido y responde como sugerencia permitida para docente", () => {
+    const response = trySasitoL3Bridge({
+      text: "registrar incidencia",
+      currentUserRole: UserRole.DOCENTE,
+      env: { VITE_ENABLE_SASITO_L3: "true" },
+    });
+
+    expect(response).not.toBeNull();
+    expect(response?.intent.intent).toBe("open_quick_register");
+    expect(response?.action.executionType).toBe("open_modal");
+    expect(response?.text).toMatch(/Puedo ayudarte a Abrir Registro Rapido/);
+    expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("con flag activa captura incidencia generica antes del flujo legacy", () => {
+    const response = trySasitoL3Bridge({
+      text: "incidencia",
+      currentUserRole: UserRole.DOCENTE,
+      env: { VITE_ENABLE_SASITO_L3: "true" },
+    });
+
+    expect(response).not.toBeNull();
+    expect(response?.intent.intent).toBe("open_quick_register");
+    expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("con flag activa deniega Registro Rapido para alumno sin ejecutar acciones", () => {
+    const response = trySasitoL3Bridge({
+      text: "registrar incidencia",
+      currentUserRole: UserRole.ALUMNO,
+      env: { VITE_ENABLE_SASITO_L3: "true" },
+    });
+
+    expect(response).not.toBeNull();
+    expect(response?.intent.intent).toBe("open_quick_register");
+    expect(response?.action.executionType).toBe("deny");
+    expect(response?.state).toBe("alert");
+    expect(response?.text).toMatch(/no tiene autorizado/i);
+    expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("con flag activa detecta Diagnostico Colectivo sin navegar automaticamente", () => {
+    const response = trySasitoL3Bridge({
+      text: "diagnostico colectivo",
+      currentUserRole: UserRole.DOCENTE,
+      env: { VITE_ENABLE_SASITO_L3: "true" },
+    });
+
+    expect(response).not.toBeNull();
+    expect(response?.intent.intent).toBe("open_collective_diagnosis");
+    expect(response?.action.moduleTarget).toBe(AppModule.DIAGNOSTICO);
+    expect(response?.action.executionType).toBe("navigate");
+    expect(response?.text).toMatch(/no navegare automaticamente/i);
+    expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("con flag activa pide seleccionar caso para explicar que sigue", () => {
+    const response = trySasitoL3Bridge({
+      text: "que sigue",
+      currentUserRole: UserRole.ORIENTACION,
+      env: { VITE_ENABLE_SASITO_L3: "true" },
+    });
+
+    expect(response).not.toBeNull();
+    expect(response?.intent.intent).toBe("explain_next_step");
+    expect(response?.action.executionType).toBe("suggest_only");
+    expect(response?.text).toMatch(/Selecciona un caso institucional/i);
+    expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("con flag activa responde seguro para texto desconocido sin caer a acciones legacy", () => {
+    const response = trySasitoL3Bridge({
+      text: "abre cualquier cosa",
+      currentUserRole: UserRole.DOCENTE,
+      env: { VITE_ENABLE_SASITO_L3: "true" },
+    });
+
+    expect(response).not.toBeNull();
+    expect(response?.handled).toBe(false);
+    expect(response?.intent.intent).toBe("unknown");
+    expect(response?.action.executionType).toBe("deny");
+    expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("el bridge no recibe callbacks ni ejecuta acciones reales", () => {
+    const response = createSasitoBridgeResponse({
+      text: "abrir diagnostico colectivo",
+      currentUserRole: UserRole.DOCENTE,
+    });
+
+    expect(response.safeMode).toBe(true);
+    expect(response.didExecuteAction).toBe(false);
+    expect(response.action.executionType).toBe("navigate");
   });
 });


### PR DESCRIPTION
## Summary
- Bridge seguro `trySasitoL3Bridge()` en `src/components/ai/sasito/sasitoBridge.ts` detrás de `VITE_ENABLE_SASITO_L3` (default `false`)
- Con flag apagada: retorna `null`, flujo legacy intacto
- Con flag activa: respuestas textuales seguras, `didExecuteAction: false`, sin navegacion ni modales
- Keyword `incidencia` anadida a `sasitoIntentEngine.ts` para captura generica

## Archivos
| File | Cambio |
|------|--------|
| `src/components/ai/sasito/sasitoBridge.ts` | Nuevo - bridge + factory |
| `src/components/ai/SasitoAssistant.tsx` | +22 lineas - inyeccion segura en `processInput()` |
| `src/components/ai/sasito/sasitoIntentEngine.ts` | +1 keyword |
| `tests/SasitoLevel3Base.test.ts` | Nuevo - 15 tests |

## Verificacion
- `pnpm test`: 60/60
- `pnpm type-check`
- `pnpm build`

## Riesgo
- **Cero riesgo con flag apagada** - no cambia comportamiento productivo
- Con flag activa: solo sugerencias textuales seguras
- No toca: Playwright, Feria, Supabase, RLS, migrations, `api/modules/lib.ts`, `tests/FeriaHardening.test.ts`

> IMPORTANT: NO hacer merge automatico. Esperar checks verdes y confirmacion manual.