### PR TITLE
feat: strengthen Sasito level 3 deterministic intent engine

### DIFF
--- a/src/components/ai/sasito/sasitoActionCatalog.ts
+++ b/src/components/ai/sasito/sasitoActionCatalog.ts
@@ -1,6 +1,13 @@
 import { AppModule, UserRole } from "../../../types";
 import { tienePermiso } from "../../../utils/permisos";
-import type { SasitoActionDefinition, SasitoIntent, SasitoIntentResult, SasitoRuntimeContext } from "./types";
+import type {
+  SasitoActionDefinition,
+  SasitoActionResolution,
+  SasitoContextRequirement,
+  SasitoIntent,
+  SasitoIntentResult,
+  SasitoRuntimeContext,
+} from "./types";
 
 const STAFF_ROLES = [
   UserRole.DIRECTIVO,
@@ -37,6 +44,8 @@ const ACTION_CATALOG: Record<SasitoIntent, SasitoActionDefinition> = {
     allowedRoles: STAFF_ROLES,
     executionType: "show_card",
     safetyMessage: "Tu rol no tiene autorizado buscar alumnos desde Sasito.",
+    requiresContext: ["student"],
+    missingContextMessage: "Indica el nombre o matricula del alumno para buscarlo sin inventar coincidencias.",
   },
   open_student_record: {
     id: "open_student_record",
@@ -47,16 +56,20 @@ const ACTION_CATALOG: Record<SasitoIntent, SasitoActionDefinition> = {
     moduleTarget: AppModule.EXPEDIENTES,
     executionType: "navigate",
     safetyMessage: "Tu rol no tiene autorizado abrir expedientes desde Sasito.",
+    requiresContext: ["student"],
+    missingContextMessage: "Selecciona o menciona un alumno antes de abrir su expediente.",
   },
   open_health_module: {
     id: "open_health_module",
     intent: "open_health_module",
     label: "Abrir modulo de salud",
     requiredPermission: "can_view_sensitive",
-    allowedRoles: [UserRole.DIRECTIVO, UserRole.SUBDIRECCION, UserRole.ORIENTACION, UserRole.TRABAJO_SOCIAL, UserRole.MEDICO_ESCOLAR, UserRole.UDEII, UserRole.DEVELOPER, UserRole.SYSTEM_ADMIN],
+    allowedRoles: STAFF_ROLES,
     moduleTarget: AppModule.SALUD,
     executionType: "navigate",
     safetyMessage: "Tu rol no tiene autorizado consultar Salud desde Sasito.",
+    requiresContext: ["student"],
+    missingContextMessage: "Selecciona o menciona un alumno antes de consultar datos de salud.",
   },
   open_orientation_cases: {
     id: "open_orientation_cases",
@@ -95,7 +108,9 @@ const ACTION_CATALOG: Record<SasitoIntent, SasitoActionDefinition> = {
     requiredPermission: null,
     allowedRoles: STAFF_ROLES,
     executionType: "suggest_only",
-    safetyMessage: "Selecciona primero un caso o alumno para recibir una recomendacion institucional segura.",
+    safetyMessage: "Puedo explicar el siguiente paso del caso seleccionado sin ejecutar cambios automaticos.",
+    requiresContext: ["case"],
+    missingContextMessage: "Selecciona un caso institucional antes de pedir el siguiente paso.",
   },
   unknown: {
     id: "unknown",
@@ -108,11 +123,42 @@ const ACTION_CATALOG: Record<SasitoIntent, SasitoActionDefinition> = {
   },
 };
 
-const denyAction = (action: SasitoActionDefinition): SasitoActionDefinition => ({
+const hasRequiredContext = (
+  requirement: SasitoContextRequirement,
+  intentResult: SasitoIntentResult,
+  context: SasitoRuntimeContext,
+) => {
+  switch (requirement) {
+    case "student":
+      return Boolean(intentResult.entities.studentId || context.selectedStudent?.id);
+    case "case":
+      return Boolean(intentResult.entities.caseId || context.selectedCase?.id);
+    case "group":
+      return Boolean(intentResult.entities.group || context.selectedGroup);
+    case "notifications":
+      return Array.isArray(context.notifications);
+    default:
+      return false;
+  }
+};
+
+const resolveMissingContext = (
+  action: SasitoActionDefinition,
+  intentResult: SasitoIntentResult,
+  context: SasitoRuntimeContext,
+): SasitoContextRequirement[] => {
+  if (!action.requiresContext) return [];
+  return action.requiresContext.filter((requirement) => !hasRequiredContext(requirement, intentResult, context));
+};
+
+const toResolution = (
+  action: SasitoActionDefinition,
+  overrides: Partial<SasitoActionResolution>,
+): SasitoActionResolution => ({
   ...action,
-  moduleTarget: undefined,
-  executionType: "deny",
-  requiresConfirmation: false,
+  decision: "allow",
+  effectiveMessage: action.safetyMessage,
+  ...overrides,
 });
 
 export function getSasitoActionDefinition(intent: SasitoIntent): SasitoActionDefinition {
@@ -122,26 +168,63 @@ export function getSasitoActionDefinition(intent: SasitoIntent): SasitoActionDef
 export function resolveSasitoAction(
   intentResult: SasitoIntentResult,
   context: SasitoRuntimeContext,
-): SasitoActionDefinition {
+): SasitoActionResolution {
   const action = getSasitoActionDefinition(intentResult.intent);
 
-  if (action.executionType === "deny") return action;
+  if (action.executionType === "deny" || intentResult.intent === "unknown") {
+    return toResolution(action, {
+      decision: "deny",
+      executionType: "deny",
+      moduleTarget: undefined,
+      denialReason: "unknown",
+      requiresConfirmation: false,
+      effectiveMessage: action.safetyMessage,
+    });
+  }
 
   if (!action.allowedRoles.includes(context.currentUserRole)) {
-    return denyAction(action);
+    return toResolution(action, {
+      decision: "deny",
+      moduleTarget: undefined,
+      executionType: "deny",
+      denialReason: "role",
+      requiresConfirmation: false,
+      effectiveMessage: action.safetyMessage,
+    });
   }
 
   if (action.requiredPermission && !tienePermiso(context.permissions, action.requiredPermission)) {
-    return denyAction(action);
+    return toResolution(action, {
+      decision: "deny",
+      moduleTarget: undefined,
+      executionType: "deny",
+      denialReason: "permission",
+      requiresConfirmation: false,
+      effectiveMessage: action.safetyMessage,
+    });
   }
 
-  if (action.intent === "explain_next_step" && !context.selectedCase) {
-    return {
-      ...action,
+  const missingContext = resolveMissingContext(action, intentResult, context);
+  if (missingContext.length > 0) {
+    return toResolution(action, {
+      decision: "needs_context",
       executionType: "suggest_only",
-      safetyMessage: "Selecciona un caso institucional antes de pedir el siguiente paso.",
-    };
+      moduleTarget: undefined,
+      missingContext,
+      requiresConfirmation: false,
+      effectiveMessage: action.missingContextMessage || action.safetyMessage,
+    });
   }
 
-  return action;
+  if (action.executionType === "suggest_only") {
+    return toResolution(action, {
+      decision: "suggest_only",
+      effectiveMessage: action.safetyMessage,
+    });
+  }
+
+  return toResolution(action, {
+    decision: "allow",
+    effectiveMessage: `Accion permitida: ${action.label}.`,
+  });
 }

--- a/src/components/ai/sasito/sasitoBridge.ts
+++ b/src/components/ai/sasito/sasitoBridge.ts
@@ -2,7 +2,7 @@ import { AppModule } from "../../../types";
 import { buildSasitoContext } from "./sasitoContextProvider";
 import { detectSasitoIntent } from "./sasitoIntentEngine";
 import { resolveSasitoAction } from "./sasitoActionCatalog";
-import type { SasitoActionDefinition, SasitoIntentResult } from "./types";
+import type { SasitoActionResolution, SasitoDecision, SasitoIntentResult, SasitoPlan } from "./types";
 
 type SasitoBridgeEnv = {
   VITE_ENABLE_SASITO_L3?: string | boolean;
@@ -23,11 +23,14 @@ export interface SasitoBridgeResponse {
   state: SasitoBridgeState;
   actionLabel: string;
   intent: SasitoIntentResult;
-  action: SasitoActionDefinition;
+  action: SasitoActionResolution;
+  decision: SasitoDecision;
+  plan: SasitoPlan;
   debug: {
     intent: SasitoIntentResult["intent"];
     confidence: number;
-    executionType: SasitoActionDefinition["executionType"];
+    decision: SasitoDecision;
+    executionType: SasitoActionResolution["executionType"];
     actionId: string;
     moduleTarget?: AppModule;
   };
@@ -38,11 +41,16 @@ export function isSasitoL3Enabled(env?: SasitoBridgeEnv): boolean {
   return value === true || value === "true";
 }
 
-const getAllowedActionText = (action: SasitoActionDefinition): string => {
+const getAllowedActionText = (action: SasitoActionResolution, notificationCount: number): string => {
+  if (action.decision === "deny" || action.decision === "needs_context") return action.effectiveMessage;
+
   switch (action.executionType) {
     case "open_modal":
       return `Puedo ayudarte a ${action.label}. En esta fase segura no abrire modales automaticamente.`;
     case "navigate":
+      if (action.intent === "show_notifications" && notificationCount === 0) {
+        return "No detecto notificaciones pendientes. Puedo abrir el centro de notificaciones, pero no inventare avisos.";
+      }
       return `Puedo ayudarte a ${action.label}. En esta fase segura no navegare automaticamente.`;
     case "show_card":
       return `Puedo ayudarte a ${action.label}. En esta fase segura solo te doy la guia textual.`;
@@ -58,9 +66,9 @@ const getAllowedActionText = (action: SasitoActionDefinition): string => {
   }
 };
 
-const getResponseState = (action: SasitoActionDefinition): SasitoBridgeState => {
-  if (action.executionType === "deny") return "alert";
-  if (action.executionType === "suggest_only" || action.requiresConfirmation) return "attention";
+const getResponseState = (action: SasitoActionResolution): SasitoBridgeState => {
+  if (action.decision === "deny") return "alert";
+  if (action.decision === "needs_context" || action.decision === "suggest_only" || action.requiresConfirmation) return "attention";
   return "calm";
 };
 
@@ -69,19 +77,29 @@ export function createSasitoBridgeResponse(input: SasitoBridgeInput): SasitoBrid
   const intent = detectSasitoIntent({ text: input.text, context });
   const action = resolveSasitoAction(intent, context);
   const handled = intent.intent !== "unknown";
+  const plan: SasitoPlan = {
+    intent,
+    action,
+    decision: action.decision,
+    safeMode: true,
+    didExecuteAction: false,
+  };
 
   return {
     handled,
     safeMode: true,
     didExecuteAction: false,
-    text: getAllowedActionText(action),
+    text: getAllowedActionText(action, context.notifications.length),
     state: getResponseState(action),
     actionLabel: "ENTENDIDO",
     intent,
     action,
+    decision: action.decision,
+    plan,
     debug: {
       intent: intent.intent,
       confidence: intent.confidence,
+      decision: action.decision,
       executionType: action.executionType,
       actionId: action.id,
       moduleTarget: action.moduleTarget,

--- a/src/components/ai/sasito/sasitoContextProvider.ts
+++ b/src/components/ai/sasito/sasitoContextProvider.ts
@@ -4,10 +4,11 @@ import { PERMISOS_POR_ROL, type PermisosSASE } from "../../../utils/permisos";
 import type { SystemState } from "../../../types/systemState";
 import type { SasitoRuntimeContext, SasitoSelectedCase, SasitoSelectedStudent } from "./types";
 
-interface SasitoContextSource {
+export interface SasitoContextSource {
   currentUserRole?: UserRole;
   currentUserProfile?: unknown | null;
   currentModule?: AppModule;
+  currentRoute?: string;
   currentRouteHash?: string;
   selectedStudent?: SasitoSelectedStudent | null;
   selectedGroup?: string | null;
@@ -23,8 +24,9 @@ const resolvePermissions = (role: UserRole, permissions?: PermisosSASE): Permiso
   return PERMISOS_POR_ROL[role] || PERMISOS_POR_ROL.guest;
 };
 
-const getCurrentRouteHash = (provided?: string) => {
-  if (provided) return provided;
+const getCurrentRouteHash = (providedHash?: string, providedRoute?: string) => {
+  if (providedHash) return providedHash;
+  if (providedRoute) return providedRoute;
   if (typeof window === "undefined") return "";
   return window.location.hash || "";
 };
@@ -36,7 +38,7 @@ export function buildSasitoContext(source: SasitoContextSource): SasitoRuntimeCo
     currentUserRole: role,
     currentUserProfile: source.currentUserProfile ?? null,
     currentModule: source.currentModule || AppModule.HOME,
-    currentRouteHash: getCurrentRouteHash(source.currentRouteHash),
+    currentRouteHash: getCurrentRouteHash(source.currentRouteHash, source.currentRoute),
     selectedStudent: source.selectedStudent ?? null,
     selectedGroup: source.selectedGroup ?? null,
     selectedCase: source.selectedCase ?? null,

--- a/src/components/ai/sasito/sasitoIntentEngine.ts
+++ b/src/components/ai/sasito/sasitoIntentEngine.ts
@@ -2,26 +2,59 @@ import { AppModule } from "../../../types";
 import type { Student } from "../../../types";
 import type { SasitoEntities, SasitoIntent, SasitoIntentResult, SasitoRuntimeContext } from "./types";
 
-interface SasitoIntentInput {
+export interface SasitoIntentInput {
   text: string;
   context: SasitoRuntimeContext;
 }
 
-const normalizeText = (value: string) =>
+const LOW_CONFIDENCE_THRESHOLD = 0.65;
+
+export const normalizeSasitoText = (value: string) =>
   value
     .toLowerCase()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9@.\s-]/g, " ")
+    .replace(/\s+/g, " ")
     .trim();
 
 const hasAny = (normalizedText: string, keywords: string[]) =>
-  keywords.some((keyword) => normalizedText.includes(normalizeText(keyword)));
+  keywords.some((keyword) => normalizedText.includes(normalizeSasitoText(keyword)));
+
+const mergeEntities = (...entities: SasitoEntities[]) =>
+  entities.reduce<SasitoEntities>((merged, entity) => {
+    const rawMatches = [...(merged.rawMatches || []), ...(entity.rawMatches || [])];
+    return {
+      ...merged,
+      ...entity,
+      rawMatches: rawMatches.length > 0 ? rawMatches : undefined,
+    };
+  }, {});
+
+const selectedStudentEntity = (context: SasitoRuntimeContext): SasitoEntities => {
+  if (!context.selectedStudent) return {};
+
+  return {
+    studentId: context.selectedStudent.id,
+    studentName: context.selectedStudent.name,
+    group: context.selectedStudent.group,
+    rawMatches: [context.selectedStudent.name],
+    source: "selected_context",
+  };
+};
 
 const findStudentMention = (text: string, students: Student[]): SasitoEntities => {
-  const normalizedText = normalizeText(text);
+  if (students.length === 0) return {};
+
+  const normalizedText = normalizeSasitoText(text);
   const match = students.find((student) => {
-    const normalizedName = normalizeText(student.name || "");
-    return normalizedName.length > 2 && normalizedText.includes(normalizedName);
+    const normalizedName = normalizeSasitoText(student.name || "");
+    const normalizedMatricula = normalizeSasitoText(student.matricula || "");
+    return (
+      normalizedName.length > 2 && normalizedText.includes(normalizedName)
+    ) || (
+      normalizedMatricula.length > 2 && normalizedText.includes(normalizedMatricula)
+    );
   });
 
   if (!match) return {};
@@ -31,8 +64,56 @@ const findStudentMention = (text: string, students: Student[]): SasitoEntities =
     studentName: match.name,
     group: match.group,
     rawMatches: [match.name],
+    source: "explicit_text",
   };
 };
+
+const findGroupMention = (text: string, context: SasitoRuntimeContext): SasitoEntities => {
+  const normalizedText = normalizeSasitoText(text).toUpperCase();
+  const match = normalizedText.match(/\b([1-6])\s*-?\s*([A-Z])\b/);
+
+  if (match) {
+    return {
+      group: `${match[1]}${match[2]}`,
+      rawMatches: [match[0]],
+      source: "explicit_text",
+    };
+  }
+
+  if (context.selectedGroup && hasAny(normalizedText.toLowerCase(), ["grupo", "mi grupo", "este grupo"])) {
+    return {
+      group: context.selectedGroup,
+      rawMatches: [context.selectedGroup],
+      source: "selected_context",
+    };
+  }
+
+  return {};
+};
+
+const findCaseContext = (text: string, context: SasitoRuntimeContext): SasitoEntities => {
+  if (!context.selectedCase) return {};
+
+  const normalizedText = normalizeSasitoText(text);
+  if (!hasAny(normalizedText, ["caso", "este caso", "seguimiento", "que sigue", "siguiente paso"])) {
+    return {};
+  }
+
+  return {
+    caseId: context.selectedCase.id,
+    studentId: context.selectedCase.studentId,
+    studentName: context.selectedCase.studentName,
+    caseStatus: context.selectedCase.status,
+    rawMatches: [context.selectedCase.id],
+    source: "selected_context",
+  };
+};
+
+const moduleEntity = (moduleKeyword: string, moduleTarget: AppModule): SasitoEntities => ({
+  moduleKeyword,
+  moduleTarget,
+  rawMatches: [moduleKeyword],
+});
 
 const result = (
   intent: SasitoIntent,
@@ -41,51 +122,60 @@ const result = (
   entities: SasitoEntities = {},
   moduleTarget?: AppModule,
 ): SasitoIntentResult => ({
-  intent,
+  intent: confidence < LOW_CONFIDENCE_THRESHOLD ? "unknown" : intent,
   confidence,
-  entities,
-  moduleTarget,
-  reason,
+  entities: confidence < LOW_CONFIDENCE_THRESHOLD ? {} : entities,
+  moduleTarget: confidence < LOW_CONFIDENCE_THRESHOLD ? undefined : moduleTarget,
+  reason: confidence < LOW_CONFIDENCE_THRESHOLD ? "Confianza insuficiente para ejecutar una accion segura." : reason,
 });
 
 export function detectSasitoIntent({ text, context }: SasitoIntentInput): SasitoIntentResult {
-  const normalized = normalizeText(text);
-  const studentEntities = findStudentMention(text, context.students || []);
+  const normalized = normalizeSasitoText(text);
+  const explicitStudent = findStudentMention(text, context.students || []);
+  const baseStudent = Object.keys(explicitStudent).length > 0 ? explicitStudent : selectedStudentEntity(context);
+  const group = findGroupMention(text, context);
+  const selectedCase = findCaseContext(text, context);
+  const contextualEntities = mergeEntities(baseStudent, group, selectedCase);
 
   if (!normalized) {
     return result("unknown", 0, "No hay texto para clasificar.");
   }
 
   if (hasAny(normalized, ["reporte rapido", "registro rapido", "incidencia", "registrar incidencia", "crear incidencia", "levantar reporte", "reportar alumno"])) {
-    return result("open_quick_register", 0.92, "El usuario solicita registrar una incidencia o reporte rapido.");
+    return result("open_quick_register", 0.94, "El usuario solicita registrar una incidencia o reporte rapido.", contextualEntities);
   }
 
-  if (hasAny(normalized, ["diagnostico colectivo", "diagnostico de grupo", "diagnostico grupal", "reporte colectivo"])) {
-    return result("open_collective_diagnosis", 0.9, "El usuario solicita abrir Diagnostico Colectivo.", {}, AppModule.DIAGNOSTICO);
+  if (hasAny(normalized, ["diagnostico colectivo", "diagnostico de grupo", "diagnostico grupal", "reporte colectivo", "diagnostico 1a", "diagnostico 2b", "diagnostico 3c"])) {
+    const entities = mergeEntities(contextualEntities, moduleEntity("diagnostico colectivo", AppModule.DIAGNOSTICO));
+    return result("open_collective_diagnosis", 0.92, "El usuario solicita abrir Diagnostico Colectivo.", entities, AppModule.DIAGNOSTICO);
   }
 
-  if (hasAny(normalized, ["que sigue", "siguiente paso", "que hago", "como procedo", "proxima accion"])) {
-    return result("explain_next_step", 0.88, "El usuario pide orientacion operativa sobre el siguiente paso.");
+  if (hasAny(normalized, ["que sigue", "siguiente paso", "que hago", "como procedo", "proxima accion", "siguiente accion"])) {
+    return result("explain_next_step", 0.9, "El usuario pide orientacion operativa sobre el siguiente paso.", contextualEntities);
   }
 
-  if (hasAny(normalized, ["salud", "medico", "enfermeria", "alergia", "padecimiento", "medicamento"])) {
-    return result("open_health_module", 0.86, "El usuario solicita informacion o modulo de salud.", studentEntities, AppModule.SALUD);
+  if (hasAny(normalized, ["salud", "medico", "servicio medico", "enfermeria", "alergia", "padecimiento", "medicamento", "historial medico"])) {
+    const entities = mergeEntities(contextualEntities, moduleEntity("salud", AppModule.SALUD));
+    return result("open_health_module", 0.88, "El usuario solicita informacion o modulo de salud.", entities, AppModule.SALUD);
   }
 
-  if (hasAny(normalized, ["orientacion", "casos de orientacion", "socioemocional", "canalizacion", "seguimiento psicopedagogico"])) {
-    return result("open_orientation_cases", 0.84, "El usuario solicita casos de Orientacion.", studentEntities, AppModule.REPORTES);
+  if (hasAny(normalized, ["orientacion", "casos de orientacion", "casos orientacion", "socioemocional", "canalizacion", "seguimiento psicopedagogico"])) {
+    const entities = mergeEntities(contextualEntities, moduleEntity("orientacion", AppModule.REPORTES));
+    return result("open_orientation_cases", 0.86, "El usuario solicita casos de Orientacion.", entities, AppModule.REPORTES);
   }
 
-  if (hasAny(normalized, ["expediente", "historial", "archivo del alumno", "record del alumno", "antecedentes"])) {
-    return result("open_student_record", 0.84, "El usuario solicita abrir o consultar expediente.", studentEntities, AppModule.EXPEDIENTES);
+  if (hasAny(normalized, ["abrir expediente", "expediente", "historial", "archivo del alumno", "record del alumno", "antecedentes"])) {
+    const entities = mergeEntities(contextualEntities, moduleEntity("expedientes", AppModule.EXPEDIENTES));
+    return result("open_student_record", 0.86, "El usuario solicita abrir o consultar expediente.", entities, AppModule.EXPEDIENTES);
   }
 
-  if (hasAny(normalized, ["notificaciones", "avisos", "campana", "pendientes por leer"])) {
-    return result("show_notifications", 0.86, "El usuario solicita revisar notificaciones.", {}, AppModule.NOTIFICATIONS);
+  if (hasAny(normalized, ["notificaciones", "avisos", "campana", "pendientes por leer", "pendientes"])) {
+    const entities = moduleEntity("notificaciones", AppModule.NOTIFICATIONS);
+    return result("show_notifications", 0.88, "El usuario solicita revisar notificaciones.", entities, AppModule.NOTIFICATIONS);
   }
 
-  if (hasAny(normalized, ["buscar alumno", "busca a", "encuentra a", "localiza a", "donde esta"]) || studentEntities.studentId) {
-    return result("search_student", 0.78, "El usuario solicita busqueda de alumno.", studentEntities);
+  if (hasAny(normalized, ["buscar alumno", "buscar a", "busca a", "encuentra a", "localiza a", "donde esta"]) || explicitStudent.studentId) {
+    return result("search_student", 0.8, "El usuario solicita busqueda de alumno.", mergeEntities(explicitStudent, group));
   }
 
   return result("unknown", 0.2, "No se encontro una intencion institucional segura.");

--- a/src/components/ai/sasito/types.ts
+++ b/src/components/ai/sasito/types.ts
@@ -20,13 +20,28 @@ export type SasitoExecutionType =
   | "suggest_only"
   | "deny";
 
+export type SasitoDecision =
+  | "allow"
+  | "deny"
+  | "suggest_only"
+  | "needs_context";
+
+export type SasitoContextRequirement =
+  | "student"
+  | "case"
+  | "group"
+  | "notifications";
+
 export interface SasitoEntities {
   studentId?: string;
   studentName?: string;
   group?: string;
   caseId?: string;
+  caseStatus?: string;
   moduleKeyword?: string;
+  moduleTarget?: AppModule;
   rawMatches?: string[];
+  source?: "selected_context" | "explicit_text";
 }
 
 export interface SasitoIntentResult {
@@ -74,4 +89,21 @@ export interface SasitoActionDefinition {
   executionType: SasitoExecutionType;
   safetyMessage: string;
   requiresConfirmation?: boolean;
+  requiresContext?: SasitoContextRequirement[];
+  missingContextMessage?: string;
+}
+
+export interface SasitoActionResolution extends SasitoActionDefinition {
+  decision: SasitoDecision;
+  denialReason?: "role" | "permission" | "unknown";
+  missingContext?: SasitoContextRequirement[];
+  effectiveMessage: string;
+}
+
+export interface SasitoPlan {
+  intent: SasitoIntentResult;
+  action: SasitoActionResolution;
+  decision: SasitoDecision;
+  safeMode: true;
+  didExecuteAction: false;
 }

--- a/tests/SasitoLevel3Base.test.ts
+++ b/tests/SasitoLevel3Base.test.ts
@@ -1,70 +1,189 @@
 import { describe, expect, it } from "vitest";
-import { AppModule, UserRole } from "../src/types";
+import { AppModule, CaseState, UserRole, type Student } from "../src/types";
 import { detectSasitoIntent } from "../src/components/ai/sasito/sasitoIntentEngine";
 import { resolveSasitoAction } from "../src/components/ai/sasito/sasitoActionCatalog";
 import { buildSasitoContext } from "../src/components/ai/sasito/sasitoContextProvider";
 import { createSasitoBridgeResponse, isSasitoL3Enabled, trySasitoL3Bridge } from "../src/components/ai/sasito/sasitoBridge";
 
-describe("Sasito Nivel 3 base", () => {
+const valentina: Student = {
+  id: "student-valentina",
+  matricula: "VAL-001",
+  name: "Valentina Rios",
+  group: "3B",
+  avatar: "/SASE_ICON.png",
+  caseState: CaseState.OBSERVADO,
+  incidents: [],
+  justificantes: [],
+};
+
+const buildContext = (overrides: Parameters<typeof buildSasitoContext>[0] = {}) =>
+  buildSasitoContext({
+    currentUserRole: UserRole.ORIENTACION,
+    students: [valentina],
+    ...overrides,
+  });
+
+describe("Sasito Nivel 3 intent engine deterministico", () => {
   it("detecta registrar incidencia como open_quick_register", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
-    const result = detectSasitoIntent({ text: "Necesito registrar incidencia", context });
+    const result = detectSasitoIntent({ text: "Necesito registrar incidencia", context: buildContext() });
 
     expect(result.intent).toBe("open_quick_register");
     expect(result.confidence).toBeGreaterThan(0.8);
   });
 
+  it("detecta buscar a Valentina como search_student", () => {
+    const result = detectSasitoIntent({ text: "buscar a Valentina Rios", context: buildContext() });
+
+    expect(result.intent).toBe("search_student");
+    expect(result.entities.studentId).toBe(valentina.id);
+    expect(result.entities.source).toBe("explicit_text");
+  });
+
+  it("detecta abrir expediente de Valentina como open_student_record", () => {
+    const result = detectSasitoIntent({ text: "abrir expediente de Valentina Rios", context: buildContext() });
+
+    expect(result.intent).toBe("open_student_record");
+    expect(result.moduleTarget).toBe(AppModule.EXPEDIENTES);
+    expect(result.entities.studentId).toBe(valentina.id);
+  });
+
+  it("detecta ver salud del alumno como open_health_module usando selectedStudent", () => {
+    const context = buildContext({ selectedStudent: { id: valentina.id, name: valentina.name, group: valentina.group } });
+    const result = detectSasitoIntent({ text: "ver salud del alumno", context });
+
+    expect(result.intent).toBe("open_health_module");
+    expect(result.moduleTarget).toBe(AppModule.SALUD);
+    expect(result.entities.studentId).toBe(valentina.id);
+    expect(result.entities.source).toBe("selected_context");
+  });
+
+  it("detecta casos de orientacion como open_orientation_cases", () => {
+    const result = detectSasitoIntent({ text: "casos de orientación", context: buildContext() });
+
+    expect(result.intent).toBe("open_orientation_cases");
+    expect(result.moduleTarget).toBe(AppModule.REPORTES);
+  });
+
   it("detecta diagnostico colectivo como open_collective_diagnosis", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
-    const result = detectSasitoIntent({ text: "Abrir diagnóstico colectivo", context });
+    const result = detectSasitoIntent({ text: "Abrir diagnóstico colectivo para 2B", context: buildContext() });
 
     expect(result.intent).toBe("open_collective_diagnosis");
     expect(result.moduleTarget).toBe(AppModule.DIAGNOSTICO);
+    expect(result.entities.group).toBe("2B");
+  });
+
+  it("detecta notificaciones como show_notifications", () => {
+    const result = detectSasitoIntent({ text: "ver notificaciones", context: buildContext() });
+
+    expect(result.intent).toBe("show_notifications");
+    expect(result.moduleTarget).toBe(AppModule.NOTIFICATIONS);
   });
 
   it("detecta que sigue como explain_next_step", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.ORIENTACION });
-    const result = detectSasitoIntent({ text: "¿Qué sigue con este caso?", context });
+    const result = detectSasitoIntent({ text: "¿Qué sigue con este caso?", context: buildContext() });
 
     expect(result.intent).toBe("explain_next_step");
   });
 
-  it("ALUMNO recibe deny para Registro Rapido", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.ALUMNO });
-    const intent = detectSasitoIntent({ text: "registrar incidencia", context });
+  it("devuelve unknown para texto ambiguo", () => {
+    const result = detectSasitoIntent({ text: "abre cualquier cosa", context: buildContext() });
+
+    expect(result.intent).toBe("unknown");
+    expect(result.confidence).toBeLessThan(0.65);
+  });
+
+  it("no inventa alumno cuando students esta vacio", () => {
+    const context = buildContext({ students: [] });
+    const result = detectSasitoIntent({ text: "buscar a Valentina", context });
+
+    expect(result.intent).toBe("search_student");
+    expect(result.entities.studentId).toBeUndefined();
+  });
+});
+
+describe("Sasito Nivel 3 RBAC y resolucion segura", () => {
+  it("rol autorizado recibe allow para abrir expediente con alumno", () => {
+    const context = buildContext({ currentUserRole: UserRole.ORIENTACION });
+    const intent = detectSasitoIntent({ text: "abrir expediente de Valentina Rios", context });
     const action = resolveSasitoAction(intent, context);
 
+    expect(action.decision).toBe("allow");
+    expect(action.executionType).toBe("navigate");
+    expect(action.moduleTarget).toBe(AppModule.EXPEDIENTES);
+  });
+
+  it("rol no autorizado recibe deny", () => {
+    const context = buildContext({ currentUserRole: UserRole.ALUMNO });
+    const intent = detectSasitoIntent({ text: "abrir expediente de Valentina Rios", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.decision).toBe("deny");
     expect(action.executionType).toBe("deny");
     expect(action.moduleTarget).toBeUndefined();
   });
 
-  it("GUEST recibe deny para Registro Rapido", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.GUEST });
-    const intent = detectSasitoIntent({ text: "registrar incidencia", context });
-    const action = resolveSasitoAction(intent, context);
+  it("alumno y guest no abren registro rapido", () => {
+    for (const role of [UserRole.ALUMNO, UserRole.GUEST]) {
+      const context = buildContext({ currentUserRole: role });
+      const intent = detectSasitoIntent({ text: "registrar incidencia", context });
+      const action = resolveSasitoAction(intent, context);
 
-    expect(action.executionType).toBe("deny");
-    expect(action.moduleTarget).toBeUndefined();
+      expect(action.decision).toBe("deny");
+      expect(action.executionType).toBe("deny");
+      expect(action.moduleTarget).toBeUndefined();
+    }
   });
 
-  it("docente recibe open_modal para Registro Rapido", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
+  it("docente autorizado recibe allow para Registro Rapido sin ejecutar", () => {
+    const context = buildContext({ currentUserRole: UserRole.DOCENTE });
     const intent = detectSasitoIntent({ text: "registrar incidencia", context });
     const action = resolveSasitoAction(intent, context);
 
+    expect(action.decision).toBe("allow");
     expect(action.executionType).toBe("open_modal");
-    expect(action.id).toBe("open_quick_register");
   });
 
-  it("accion no autorizada no navega ni abre modal", () => {
-    const context = buildSasitoContext({ currentUserRole: UserRole.DOCENTE });
-    const intent = detectSasitoIntent({ text: "abrir modulo de salud", context });
+  it("docente sin can_view_sensitive no abre Salud", () => {
+    const context = buildContext({ currentUserRole: UserRole.DOCENTE, selectedStudent: { id: valentina.id, name: valentina.name, group: valentina.group } });
+    const intent = detectSasitoIntent({ text: "ver salud del alumno", context });
     const action = resolveSasitoAction(intent, context);
 
-    expect(action.executionType).toBe("deny");
-    expect(action.executionType).not.toBe("navigate");
-    expect(action.executionType).not.toBe("open_modal");
+    expect(action.decision).toBe("deny");
+    expect(action.denialReason).toBe("permission");
     expect(action.moduleTarget).toBeUndefined();
+  });
+
+  it("roles no autorizados no abren Diagnostico Colectivo", () => {
+    const context = buildContext({ currentUserRole: UserRole.ORIENTACION });
+    const intent = detectSasitoIntent({ text: "diagnostico colectivo", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.decision).toBe("deny");
+    expect(action.executionType).toBe("deny");
+    expect(action.moduleTarget).toBeUndefined();
+  });
+
+  it("sin selectedCase, que sigue pide seleccionar caso", () => {
+    const context = buildContext({ currentUserRole: UserRole.ORIENTACION, selectedCase: null });
+    const intent = detectSasitoIntent({ text: "que sigue", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(action.decision).toBe("needs_context");
+    expect(action.executionType).toBe("suggest_only");
+    expect(action.effectiveMessage).toMatch(/Selecciona un caso institucional/i);
+  });
+
+  it("selectedCase habilita explain_next_step como suggest_only", () => {
+    const context = buildContext({
+      currentUserRole: UserRole.ORIENTACION,
+      selectedCase: { id: "case-1", studentId: valentina.id, studentName: valentina.name, status: "abierto" },
+    });
+    const intent = detectSasitoIntent({ text: "que sigue con este caso", context });
+    const action = resolveSasitoAction(intent, context);
+
+    expect(intent.entities.caseId).toBe("case-1");
+    expect(action.decision).toBe("suggest_only");
+    expect(action.effectiveMessage).not.toMatch(/Selecciona un caso institucional antes/i);
   });
 });
 
@@ -82,7 +201,7 @@ describe("Sasito Nivel 3 bridge seguro", () => {
     expect(response).toBeNull();
   });
 
-  it("con flag activa detecta Registro Rapido y responde como sugerencia permitida para docente", () => {
+  it("con flag activa detecta Registro Rapido y responde como accion permitida para docente", () => {
     const response = trySasitoL3Bridge({
       text: "registrar incidencia",
       currentUserRole: UserRole.DOCENTE,
@@ -91,20 +210,9 @@ describe("Sasito Nivel 3 bridge seguro", () => {
 
     expect(response).not.toBeNull();
     expect(response?.intent.intent).toBe("open_quick_register");
+    expect(response?.decision).toBe("allow");
     expect(response?.action.executionType).toBe("open_modal");
-    expect(response?.text).toMatch(/Puedo ayudarte a Abrir Registro Rapido/);
-    expect(response?.didExecuteAction).toBe(false);
-  });
-
-  it("con flag activa captura incidencia generica antes del flujo legacy", () => {
-    const response = trySasitoL3Bridge({
-      text: "incidencia",
-      currentUserRole: UserRole.DOCENTE,
-      env: { VITE_ENABLE_SASITO_L3: "true" },
-    });
-
-    expect(response).not.toBeNull();
-    expect(response?.intent.intent).toBe("open_quick_register");
+    expect(response?.text).toMatch(/no abrire modales automaticamente/i);
     expect(response?.didExecuteAction).toBe(false);
   });
 
@@ -117,6 +225,7 @@ describe("Sasito Nivel 3 bridge seguro", () => {
 
     expect(response).not.toBeNull();
     expect(response?.intent.intent).toBe("open_quick_register");
+    expect(response?.decision).toBe("deny");
     expect(response?.action.executionType).toBe("deny");
     expect(response?.state).toBe("alert");
     expect(response?.text).toMatch(/no tiene autorizado/i);
@@ -125,20 +234,21 @@ describe("Sasito Nivel 3 bridge seguro", () => {
 
   it("con flag activa detecta Diagnostico Colectivo sin navegar automaticamente", () => {
     const response = trySasitoL3Bridge({
-      text: "diagnostico colectivo",
+      text: "diagnostico colectivo para 3C",
       currentUserRole: UserRole.DOCENTE,
       env: { VITE_ENABLE_SASITO_L3: "true" },
     });
 
     expect(response).not.toBeNull();
     expect(response?.intent.intent).toBe("open_collective_diagnosis");
+    expect(response?.intent.entities.group).toBe("3C");
     expect(response?.action.moduleTarget).toBe(AppModule.DIAGNOSTICO);
     expect(response?.action.executionType).toBe("navigate");
     expect(response?.text).toMatch(/no navegare automaticamente/i);
     expect(response?.didExecuteAction).toBe(false);
   });
 
-  it("con flag activa pide seleccionar caso para explicar que sigue", () => {
+  it("con flag activa pide contexto para que sigue si no hay caso", () => {
     const response = trySasitoL3Bridge({
       text: "que sigue",
       currentUserRole: UserRole.ORIENTACION,
@@ -147,9 +257,21 @@ describe("Sasito Nivel 3 bridge seguro", () => {
 
     expect(response).not.toBeNull();
     expect(response?.intent.intent).toBe("explain_next_step");
-    expect(response?.action.executionType).toBe("suggest_only");
+    expect(response?.decision).toBe("needs_context");
     expect(response?.text).toMatch(/Selecciona un caso institucional/i);
     expect(response?.didExecuteAction).toBe(false);
+  });
+
+  it("notificaciones vacio no inventa pendientes", () => {
+    const response = createSasitoBridgeResponse({
+      text: "ver notificaciones",
+      currentUserRole: UserRole.DOCENTE,
+      notifications: [],
+    });
+
+    expect(response.intent.intent).toBe("show_notifications");
+    expect(response.text).toMatch(/No detecto notificaciones pendientes/i);
+    expect(response.didExecuteAction).toBe(false);
   });
 
   it("con flag activa responde seguro para texto desconocido sin caer a acciones legacy", () => {
@@ -162,6 +284,7 @@ describe("Sasito Nivel 3 bridge seguro", () => {
     expect(response).not.toBeNull();
     expect(response?.handled).toBe(false);
     expect(response?.intent.intent).toBe("unknown");
+    expect(response?.decision).toBe("deny");
     expect(response?.action.executionType).toBe("deny");
     expect(response?.didExecuteAction).toBe(false);
   });
@@ -175,5 +298,6 @@ describe("Sasito Nivel 3 bridge seguro", () => {
     expect(response.safeMode).toBe(true);
     expect(response.didExecuteAction).toBe(false);
     expect(response.action.executionType).toBe("navigate");
+    expect(response.plan.didExecuteAction).toBe(false);
   });
 });


### PR DESCRIPTION
@
## Summary
- Strengthens the existing Sasito Level 3 base as a deterministic, auditable institutional intent engine.
- Adds entity extraction for student, group, module target, and selected case context.
- Adds safe action resolution decisions: allow, deny, suggest_only, and needs_context.

## Scope
- Evolves existing Sasito files only; no new Sasito implementation.
- No LLM integration.
- No real action execution or executor.
- Bridge remains behind VITE_ENABLE_SASITO_L3 and off by default.

## Files touched
- src/components/ai/sasito/types.ts
- src/components/ai/sasito/sasitoIntentEngine.ts
- src/components/ai/sasito/sasitoActionCatalog.ts
- src/components/ai/sasito/sasitoContextProvider.ts
- src/components/ai/sasito/sasitoBridge.ts
- tests/SasitoLevel3Base.test.ts

## Supported intents
- open_quick_register
- search_student
- open_student_record
- open_health_module
- open_orientation_cases
- open_collective_diagnosis
- show_notifications
- explain_next_step
- unknown

## Guardrails
- No Supabase changes.
- No RLS changes.
- No migrations.
- No backend changes.
- No auth changes.
- No ModuleRouter changes.
- No Feria handoff changes.
- No SOS logic changes.
- No Sasito visual changes.
- No production flag changes.
- No destructive chat actions.

## Validation
- git diff --check ✅
- pnpm type-check ✅
- pnpm test ✅ 71/71
- pnpm build ✅

## Notes
This PR implements Sasito Nivel 3 Fase 1 only. It creates no executor and performs no navigation/modal/database writes from chat.
No merge automático.
