### PR TITLE
fix: build Feria handoff URL for HashRouter

### DIFF
--- a/api/modules/lib.ts
+++ b/api/modules/lib.ts
@@ -151,12 +151,15 @@ function resolveModuleBaseUrl(moduleKey: ModuleKey, dbBaseUrl: string, req: Verc
 
 function buildLaunchUrl(baseUrl: string, token: string): string {
   const hashIndex = baseUrl.indexOf("#");
-  const prefix = hashIndex >= 0 ? baseUrl.slice(0, hashIndex) : baseUrl;
-  const hash = hashIndex >= 0 ? baseUrl.slice(hashIndex) : "";
-  const url = new URL(prefix);
-
+  if (hashIndex >= 0) {
+    const prefix = baseUrl.slice(0, hashIndex);
+    const hash = baseUrl.slice(hashIndex);
+    const separator = hash.includes("?") ? "&" : "?";
+    return `${prefix}${hash}${separator}sase_token=${encodeURIComponent(token)}`;
+  }
+  const url = new URL(baseUrl);
   url.searchParams.set("sase_token", token);
-  return `${url.toString()}${hash}`;
+  return url.toString();
 }
 
 function mapTokenRole(institutionalRole: string, moduleKey: ModuleKey): string {

--- a/ops/verify-production-feria-handoff.mjs
+++ b/ops/verify-production-feria-handoff.mjs
@@ -12,8 +12,8 @@ const anonKey = env.VITE_SUPABASE_ANON_KEY;
 const serviceUrl = env.SUPABASE_URL;
 const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
 const saseBaseUrl = process.env.SASE_BASE_URL || "https://sase-310-system-ten.vercel.app";
-const feriaApiUrl = process.env.FERIA_API_URL || "https://nueva-feria-de-ciencias-2026.vercel.app/api/session/teacher/sase";
-const feriaLaunchBase = env.FERIA_APP_URL || "";
+const feriaApiUrl = process.env.FERIA_API_URL || "https://feria-alternativa.vercel.app/api/auth/sase-handoff";
+const feriaLaunchBase = env.FERIA_APP_URL || "https://feria-alternativa.vercel.app/#/auth/handoff";
 const email = process.env.SASE_PILOT_EMAIL;
 const password = process.env.SASE_PILOT_PASSWORD;
 
@@ -73,8 +73,20 @@ let handoffTarget = null;
 
 if (launchResponse.ok && launchBody?.url) {
   handoffTarget = launchBody.url;
-  const url = new URL(launchBody.url);
-  const token = url.searchParams.get("sase_token");
+
+  // Extract sase_token from hash-based URL (/auth/handoff?sase_token=<TOKEN>)
+  let token = null;
+  const hashIndex = launchBody.url.indexOf("#");
+  if (hashIndex >= 0) {
+    const hash = launchBody.url.slice(hashIndex);
+    const hashParams = new URLSearchParams(hash.includes("?") ? hash.split("?")[1] : "");
+    token = hashParams.get("sase_token");
+  }
+  if (!token) {
+    const url = new URL(launchBody.url);
+    token = url.searchParams.get("sase_token");
+  }
+
   const feriaResponse = await fetch(feriaApiUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/tests/ModulesLaunch.test.ts
+++ b/tests/ModulesLaunch.test.ts
@@ -165,7 +165,17 @@ vi.mock("@supabase/supabase-js", () => ({
 
 function decodePayloadFromUrl(urlString: string) {
   const url = new URL(urlString);
-  const token = url.searchParams.get("sase_token");
+
+  // Token may be in hash fragment (HashRouter) or before hash
+  let token = url.searchParams.get("sase_token");
+  if (!token) {
+    const hashIndex = urlString.indexOf("#");
+    if (hashIndex >= 0) {
+      const hash = urlString.slice(hashIndex);
+      const hashParams = new URLSearchParams(hash.includes("?") ? hash.split("?")[1] : "");
+      token = hashParams.get("sase_token");
+    }
+  }
   expect(token).toBeTruthy();
 
   const [payloadBase64Url, signature] = token!.split(".");
@@ -211,7 +221,7 @@ describe("Launcher de modulos externos", () => {
 
     const { url, payload, signature } = decodePayloadFromUrl(res.body.url);
     expect(url.origin + url.pathname).toBe("https://feria.example.com/");
-    expect(url.hash).toBe("#/docente");
+    expect(url.hash).toMatch(/^#\/docente\?sase_token=/);
     expect(payload.sub).toBe("teacher-1");
     expect(payload.uid).toBe("teacher-1");
     expect(payload.email).toBe(process.env.TEST_DOCENTE_EMAIL || "pilot.docente@sase.mx");
@@ -258,7 +268,7 @@ describe("Launcher de modulos externos", () => {
     expect(res.statusCode).toBe(200);
     const { payload, url } = decodePayloadFromUrl(res.body.url);
     expect(payload.module).toBe("feria");
-    expect(url.hash).toBe("#/docente");
+    expect(url.hash).toMatch(/^#\/docente\?sase_token=/);
   });
 
   it("resuelve diagnostico desde base_url relativo del catalogo", async () => {


### PR DESCRIPTION
Corrige la generación de URL de lanzamiento para módulos con HashRouter, insertando `sase_token` dentro del hash:

    https://feria-alternativa.vercel.app/#/auth/handoff?sase_token=<TOKEN>

Incluye actualización de prueba y verificador de handoff.
No cambia roles, RLS, Supabase, aliases ni variables Vercel.

### Archivos tocados
- `api/modules/lib.ts` — `buildLaunchUrl()` detecta `#` y pone el token dentro del hash
- `ops/verify-production-feria-handoff.mjs` — defaults actualizados, extracción desde hash
- `tests/ModulesLaunch.test.ts` — helper `decodePayloadFromUrl` y assertions adaptados

### Validación
- Tests module launch: 5/5 ✅
- Errores preexistentes NO relacionados (no bloquean este PR):
  - `src/agents/saseDeskAgent.ts:29` — TS2322, tipo `Tool` incompatible (rama SASE Desk aparte)
  - `src/components/FeedbackWidget.tsx:30` — TS2741, falta `AppModule.SASE_DESK` en el mapa

### No incluye
- ❌ Cambio de `FERIA_APP_URL` en Vercel (pendiente post-merge + smoke)
- ❌ Modificaciones a `mapTokenRole`, RLS, Supabase, aliases