### PR TITLE
docs: add agent operational skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ scripts/*.txt
 
 # Codex config (secrets)
 .codex/
+
+# Local agent working context
+.agent-context/

--- a/docs/agent-context-templates/CURRENT_TASK.md
+++ b/docs/agent-context-templates/CURRENT_TASK.md
@@ -1,0 +1,18 @@
+# Current Task
+
+Proyecto:
+PR:
+Rama:
+Objetivo:
+
+Permitido:
+-
+
+Prohibido:
+-
+
+Validación requerida:
+-
+
+Estado esperado:
+-

--- a/docs/agent-context-templates/DO_NOT_TOUCH.md
+++ b/docs/agent-context-templates/DO_NOT_TOUCH.md
@@ -1,0 +1,11 @@
+# Do Not Touch
+
+- package.json
+- package-lock.json
+- pnpm-lock.yaml
+- supabase/
+- supabase/migrations/
+- RLS
+- .env
+- archivos temporales
+- proyectos ajenos al agente

--- a/docs/agent-context-templates/KNOWN_DEBT.md
+++ b/docs/agent-context-templates/KNOWN_DEBT.md
@@ -1,0 +1,7 @@
+# Known Debt
+
+## Deuda técnica conocida
+-
+
+## No corregir en esta tarea
+-

--- a/docs/agent-context-templates/PROJECT_MAP.md
+++ b/docs/agent-context-templates/PROJECT_MAP.md
@@ -1,0 +1,10 @@
+# Project Map
+
+## Áreas principales
+-
+
+## Archivos clave
+-
+
+## No tocar
+-

--- a/docs/agent-skills/README.md
+++ b/docs/agent-skills/README.md
@@ -1,0 +1,29 @@
+# Agent Skills — SASE-310
+
+Estos skills son protocolos operativos para agentes IA que trabajan sobre este repositorio.
+
+Reglas generales:
+- No usar git add .
+- No hacer merge automático.
+- No hacer deploy manual.
+- No tocar Supabase/RLS/migrations sin autorización explícita.
+- No tocar package.json ni lockfiles salvo autorización explícita.
+- No corregir deuda no relacionada.
+- No ampliar alcance del PR.
+- Antes de editar, declarar archivos candidatos.
+- Después de editar, reportar diff, validaciones y riesgos.
+
+## Skills adicionales
+
+- `playwright-smoke-test.md`: validación visual/funcional antes de merge.
+- `vercel-deploy-guard.md`: control de despliegues y previews.
+- `release-manager.md`: criterios para autorizar merge manual.
+- `weekly-status-auditor.md`: resumen semanal sin inventar datos.
+- `agent-context-template.md`: reducción de tokens mediante contexto mínimo.
+
+## Uso recomendado
+
+1. Leer `scope-guard.md`.
+2. Leer el skill específico de la tarea.
+3. Leer `.agent-context/` si existe.
+4. Ejecutar solo lo permitido.

--- a/docs/agent-skills/agent-context-template.md
+++ b/docs/agent-skills/agent-context-template.md
@@ -1,0 +1,30 @@
+# Agent Context Template
+
+## Propósito
+Reducir consumo de tokens evitando que los agentes leer todo el proyecto.
+
+## Archivos locales sugeridos
+Estos archivos viven en `.agent-context/` y no se commitean:
+
+- CURRENT_TASK.md
+- PROJECT_MAP.md
+- DO_NOT_TOUCH.md
+- KNOWN_DEBT.md
+
+## Regla
+El agente debe leer primero el contexto mínimo y solo después abrir archivos específicos.
+
+## Prompt base
+MODO AHORRO DE CONTEXTO.
+
+Lee solamente:
+- .agent-context/CURRENT_TASK.md
+- .agent-context/PROJECT_MAP.md
+- .agent-context/DO_NOT_TOUCH.md
+- .agent-context/KNOWN_DEBT.md
+
+No leas todo el proyecto.
+No hagas listado recursivo completo.
+No abras archivos fuera del alcance sin justificar.
+Antes de editar, declara archivos candidatos.
+Después de editar, reporta diff y validación.

--- a/docs/agent-skills/github-ci-fix-surgeon.md
+++ b/docs/agent-skills/github-ci-fix-surgeon.md
@@ -1,0 +1,64 @@
+# GitHub CI Fix Surgeon
+
+## Propósito
+Corregir fallos de CI en un PR de forma mínima, auditable y segura.
+
+## Cuándo usarlo
+Cuando fallen:
+- lint
+- type-check
+- build
+- tests
+- CodeQL
+- security workflow
+- Frontend Validation
+
+## Prohibido
+- No merge.
+- No deploy.
+- No git add .
+- No package.json.
+- No lockfiles.
+- No Supabase/RLS/migrations.
+- No refactor amplio.
+- No deuda no relacionada.
+- No --no-verify salvo autorización explícita.
+
+## Procedimiento
+
+1. Ver PR:
+gh pr view <PR> --json url,headRefName,baseRefName,mergeStateStatus,reviewDecision,autoMergeRequest,commits,files
+
+2. Ver checks:
+gh pr checks <PR>
+
+3. Ver runs:
+gh run list --branch <BRANCH> --limit 10
+
+4. Leer logs fallidos:
+gh run view <RUN_ID> --log-failed
+
+5. Clasificar cada fallo:
+- archivo
+- línea
+- error exacto
+- causa probable
+- si es deuda previa o error del PR
+- acción recomendada
+
+6. Corregir solo el error reportado.
+
+7. Validar:
+pnpm lint
+pnpm exec tsc --noEmit
+pnpm run build
+
+8. Verificar prohibidos:
+git diff --name-only origin/main...HEAD | grep -Ei "package.json|package-lock.json|pnpm-lock.yaml|supabase|migrations|feria|AGENTS.md|SASE_AUDIT_REPORT.md|\.env|test-results|STATUS.md" || echo "OK: sin cambios prohibidos"
+
+9. Commit solo si todo está verde:
+git add <archivos-específicos>
+git commit -m "fix: stabilize CI for <PR>"
+
+10. Push:
+git push origin <branch>

--- a/docs/agent-skills/handoff-security-review.md
+++ b/docs/agent-skills/handoff-security-review.md
@@ -1,0 +1,27 @@
+# Handoff Security Review
+
+## Propósito
+Auditar integraciones entre SASE y módulos externos como Feria.
+
+## Revisar
+- firma del token
+- issuer
+- audience
+- exp
+- iat
+- nbf
+- jti
+- module
+- role
+- anti-replay
+- cookie HttpOnly
+- sesión server-side
+
+## Reglas
+- El cliente no decide rol.
+- El backend valida token.
+- Secret nunca va al frontend.
+- Tokens cortos: 1 a 5 minutos.
+- Rechazar module incorrecto.
+- Rechazar rol no permitido.
+- Rechazar token expirado o alterado.

--- a/docs/agent-skills/performance-budget-review.md
+++ b/docs/agent-skills/performance-budget-review.md
@@ -1,0 +1,25 @@
+# Performance Budget Review
+
+## Propósito
+Revisar rendimiento web sin mezclarlo con hotfixes críticos.
+
+## Métricas
+- LCP
+- CLS
+- TTFB
+- FCP
+- render-blocking
+- JS main thread
+- third-party impact
+- bundle size
+
+## Regla
+No optimizar performance dentro de PRs de seguridad, CI o hotfix institucional salvo autorización explícita.
+
+## Recomendaciones típicas
+- lazy loading por módulo
+- reducir fuentes externas
+- evitar icon packs globales
+- diferir scripts de terceros
+- code splitting
+- compresión de imágenes

--- a/docs/agent-skills/playwright-smoke-test.md
+++ b/docs/agent-skills/playwright-smoke-test.md
@@ -1,0 +1,44 @@
+# Playwright Smoke Test
+
+## Propósito
+Validar que una app o PR funciona visual y funcionalmente sin hacer pruebas profundas.
+
+## Cuándo usarlo
+- Antes de merge manual.
+- Después de un PR visual.
+- Después de cambios en rutas, dashboards o login.
+- Antes de piloto institucional.
+
+## Prohibido
+- No modificar código durante el smoke.
+- No hacer merge.
+- No hacer deploy manual.
+- No corregir errores sin autorización.
+- No actualizar snapshots sin autorización.
+
+## Procedimiento
+
+1. Confirmar rama:
+git branch --show-current
+git status --short
+
+2. Confirmar app/build:
+pnpm run build
+
+3. Ejecutar smoke:
+pnpm exec playwright test
+
+4. Si hay pruebas específicas:
+pnpm exec playwright test tests/<archivo>.spec.ts
+
+5. Capturas:
+Guardar evidencia en carpeta temporal o artefactos CI, nunca commitear `test-results/` salvo autorización.
+
+## Reporte obligatorio
+- URL probada.
+- Navegador.
+- Tests ejecutados.
+- PASS / FAIL.
+- Capturas disponibles.
+- Errores exactos.
+- Recomendación: merge / no merge / requiere ajuste.

--- a/docs/agent-skills/pr-clean-room.md
+++ b/docs/agent-skills/pr-clean-room.md
@@ -1,0 +1,44 @@
+# PR Clean Room
+
+## Propósito
+Crear o reparar PRs limpios desde una base sana.
+
+## Reglas
+- Trabajar desde origin/main.
+- No arrastrar historia contaminada.
+- No usar git add .
+- No tocar package/lockfiles sin autorización.
+- No tocar Supabase/RLS/migrations sin autorización.
+
+## Procedimiento
+
+1. Actualizar:
+git fetch origin
+
+2. Crear rama limpia:
+git checkout origin/main
+git checkout -b <branch-clean>
+
+3. Traer solo archivos permitidos:
+git restore --source=<source-branch> -- <archivo>
+
+4. Verificar:
+git diff --name-status origin/main
+git diff --stat origin/main
+
+5. Verificar prohibidos:
+git diff --name-only origin/main | grep -Ei "package.json|package-lock.json|pnpm-lock.yaml|supabase|migrations|feria|\.env" || echo "OK: sin cambios prohibidos"
+
+6. Validar:
+pnpm run build
+
+7. Staging controlado:
+git add <archivo1>
+git add <archivo2>
+
+8. Commit:
+git commit -m "<mensaje>"
+
+9. Push y PR:
+git push -u origin <branch-clean>
+gh pr create --base main --head <branch-clean>

--- a/docs/agent-skills/release-manager.md
+++ b/docs/agent-skills/release-manager.md
@@ -1,0 +1,42 @@
+# Release Manager
+
+## Propósito
+Controlar cuándo un PR puede pasar de revisión a merge manual.
+
+## Criterios mínimos para merge
+- PR limpio en alcance.
+- Checks verdes.
+- Sin archivos prohibidos.
+- Sin cambios de dependencias no autorizados.
+- Sin Supabase/RLS/migrations no autorizados.
+- Sin merge automático.
+- Smoke aprobado si aplica.
+- Riesgos documentados.
+
+## Prohibido
+- No merge automático.
+- No squash/merge sin revisión humana.
+- No cerrar PRs supersedidos hasta tener reemplazo aprobado.
+- No mezclar hotfix con refactor.
+- No mezclar performance con seguridad salvo autorización.
+
+## Procedimiento
+
+1. Ver PR:
+gh pr view <PR> --json mergeStateStatus,reviewDecision,autoMergeRequest,commits,files
+
+2. Ver checks:
+gh pr checks <PR>
+
+3. Ver diff:
+git diff --name-status origin/main...HEAD
+git diff --stat origin/main...HEAD
+
+4. Ver prohibidos:
+git diff --name-only origin/main...HEAD | grep -Ei "package.json|package-lock.json|pnpm-lock.yaml|supabase|migrations|\.env" || echo "OK"
+
+## Dictamen
+- MERGE MANUAL AUTORIZABLE
+- REQUIERE AJUSTE
+- BLOQUEAR
+- SUPERSEDER

--- a/docs/agent-skills/scope-guard.md
+++ b/docs/agent-skills/scope-guard.md
@@ -1,0 +1,31 @@
+# Scope Guard
+
+## Propósito
+Evitar que un agente amplíe el alcance de una tarea.
+
+## Reglas base
+- AG no toca Feria.
+- OC no toca SASE.
+- Codex audita, no edita.
+- Nada de merge automático.
+- Nada de deploy manual.
+- Nada de Supabase/RLS/migrations sin autorización.
+- Nada de package.json ni lockfiles sin autorización.
+- Nada de dashboards alumno sin autorización.
+- Nada de refactors amplios.
+
+## Antes de editar
+El agente debe declarar:
+- objetivo
+- archivos candidatos
+- archivos prohibidos
+- validaciones
+- riesgo esperado
+
+## Después de editar
+Debe reportar:
+- archivos modificados
+- diff resumido
+- validaciones ejecutadas
+- errores
+- recomendación: commit / no commit / bloquear

--- a/docs/agent-skills/supabase-rls-migration-guard.md
+++ b/docs/agent-skills/supabase-rls-migration-guard.md
@@ -1,0 +1,24 @@
+# Supabase RLS Migration Guard
+
+## Propósito
+Controlar cualquier cambio en base de datos, RLS, policies, grants o migrations.
+
+## Regla absoluta
+No tocar Supabase, RLS, policies, grants, schemas ni migrations sin autorización explícita.
+
+## Si una tarea requiere DB
+Antes de editar, entregar:
+- tabla afectada
+- política afectada
+- riesgo de seguridad
+- SQL propuesto
+- rollback
+- validación
+- impacto por rol
+
+## Prohibido
+- db push sin autorización
+- migration repair sin autorización
+- service_role en frontend
+- policies permisivas sin justificación
+- usar anon para datos sensibles

--- a/docs/agent-skills/vercel-deploy-guard.md
+++ b/docs/agent-skills/vercel-deploy-guard.md
@@ -1,0 +1,38 @@
+# Vercel Deploy Guard
+
+## Propósito
+Evitar despliegues manuales o ambiguos que rompan la superficie institucional.
+
+## Reglas absolutas
+- No deploy manual sin autorización.
+- No promover preview a producción sin autorización.
+- No cambiar variables de entorno sin autorización.
+- No conectar dominios sin autorización.
+- No borrar proyectos Vercel.
+- No duplicar superficies institucionales sin dictamen.
+
+## Procedimiento de revisión
+
+1. Listar proyectos/despliegues:
+vercel ls
+
+2. Revisar PR/deploy relacionado:
+gh pr view <PR>
+gh pr checks <PR>
+
+3. Confirmar:
+- proyecto Vercel correcto;
+- branch correcta;
+- commit correcto;
+- status READY;
+- no variables faltantes;
+- no producción accidental.
+
+## Reporte obligatorio
+- Proyecto Vercel.
+- URL preview.
+- Commit desplegado.
+- Rama.
+- Estado.
+- Riesgos.
+- Recomendación: usar preview / no usar / bloquear deploy.

--- a/docs/agent-skills/weekly-status-auditor.md
+++ b/docs/agent-skills/weekly-status-auditor.md
@@ -1,0 +1,31 @@
+# Weekly Status Auditor
+
+## Propósito
+Generar resumen semanal de PRs, despliegues, riesgos y prioridades sin inventar datos.
+
+## Reglas
+- No inventar incidentes.
+- No asumir merges.
+- No inferir producción si solo hay preview.
+- Citar PRs, commits y deploys reales.
+- Diferenciar mergeable de aprobable.
+
+## Revisar
+- PRs abiertos.
+- PRs mergeados.
+- Checks fallidos.
+- Deploys Vercel.
+- Threads pendientes.
+- Riesgos P1/P2.
+- PRs supersedidos.
+
+## Entregable
+- Ventana revisada.
+- PRs por proyecto.
+- Deploys.
+- Incidentes confirmados.
+- Pendientes críticos.
+- Recomendación ejecutiva.
+
+## Frase clave
+Mergeable no significa aprobable.


### PR DESCRIPTION
Adds reusable operational skills and context templates for AI agents working on SASE-310.

Includes:
- GitHub CI fix protocol
- PR clean room protocol
- Scope guard
- Supabase/RLS/migration guard
- Handoff security review
- Performance review
- Playwright smoke test protocol
- Vercel deploy guard
- Release manager
- Weekly status auditor
- Agent context templates

No application code changes.
No package or lockfile changes.
No Supabase/RLS/migration changes.
No Feria changes.
No AGENTS.md changes.
No pr_desc.md included.