### PR TITLE
fix: handle non-json module launch responses

### DIFF
--- a/src/components/ExternalModuleLauncher.tsx
+++ b/src/components/ExternalModuleLauncher.tsx
@@ -49,27 +49,30 @@ export const ExternalModuleLauncher: React.FC<{
         body: JSON.stringify({ module: module.key }),
       });
 
-      const data = await response.json();
+      const rawText = await response.text();
 
-      if (!response.ok) {
-        if (response.status === 403) {
-          setStatus("denied");
-          setErrorMsg(data.error || module.deniedMessage);
-          await logEvent(module.key.toUpperCase(), "LAUNCH_MODULE", "DENIED", { error: data.error });
-          return;
-        }
+      let data: any = null;
 
-        if (response.status === 404) {
-          setStatus("unavailable");
-          setErrorMsg(data.error || "El modulo no esta disponible en este momento.");
-          return;
-        }
-
-        throw new Error(data.error || `No se pudo lanzar ${module.name}.`);
+      try {
+        data = rawText ? JSON.parse(rawText) : null;
+      } catch {
+        throw new Error(
+          `El servidor no devolvió JSON válido para ${module.name}. Status: ${response.status}`
+        );
       }
 
-      if (!data.url) {
-        throw new Error("No se recibio una URL valida de lanzamiento.");
+      if (!response.ok) {
+        throw new Error(
+          data?.error ||
+          data?.message ||
+          `No se pudo iniciar ${module.name}. Status: ${response.status}`
+        );
+      }
+
+      if (!data?.url) {
+        throw new Error(
+          `Respuesta incompleta del servidor para ${module.name}. Falta URL de lanzamiento.`
+        );
       }
 
       setStatus("launching");


### PR DESCRIPTION
Hotfix para evitar que ExternalModuleLauncher truene con 'Unexpected end of JSON input' cuando /api/modules/launch devuelve respuesta vacía, HTML, 404 o no JSON.

Causa:
- En desarrollo local con Vite, /api/* no ejecuta Serverless Functions.
- POST /api/modules/launch puede devolver 404 vacío.
- El frontend hacía response.json() de forma optimista antes de validar la respuesta.

Cambio:
- lectura segura con response.text()
- parseo JSON protegido
- mensajes de error claros cuando el servidor no devuelve JSON o falta URL

Validación local:
- pnpm lint PASS
- pnpm type-check PASS
- pnpm test PASS 71/71
- pnpm build PASS

No toca:
- Feria
- SASE-FULL
- Supabase/RLS/migrations
- package.json
- pnpm-lock.yaml
- .env

Nota:
- El smoke con Vercel Dev quedó incompleto por reinicio de WSL. Se recomienda validar en PR/preview o levantar vercel dev limpio después.