### PR TITLE
feat: surface retained objects in institutional dashboards

### DIFF
--- a/src/components/dashboards/DashboardDireccion.tsx
+++ b/src/components/dashboards/DashboardDireccion.tsx
@@ -332,6 +332,7 @@ export const DashboardDireccion = () => {
                   <ActionButton label="Crear incidencia" icon="add_alert" onClick={() => openQuickRegister(IncidentType.CONDUCTA)} />
                 )}
                 <ActionButton label="Consultar expediente institucional" icon="folder_open" onClick={() => setCurrentModule(AppModule.EXPEDIENTES)} />
+                <ActionButton label="Control de objetos retenidos" icon="inventory_2" onClick={() => setCurrentModule(AppModule.OBJETOS_RETENIDOS)} />
                 <ActionButton label="Generar informes" icon="print" onClick={handleCreateReport} />
                 <ActionButton label="Supervisar vencidos" icon="alarm" onClick={() => toast("Filtro aplicado a casos vencidos")} />
               </div>

--- a/src/components/dashboards/DashboardPrefectura.tsx
+++ b/src/components/dashboards/DashboardPrefectura.tsx
@@ -178,6 +178,12 @@ export const DashboardPrefectura = () => {
     month: "long",
   });
 
+  const retainedObjectsCount = useMemo(() => {
+    return students
+      .flatMap((s) => s.objetosRetenidos || [])
+      .filter((obj) => obj.estado === "retenido").length;
+  }, [students]);
+
   // --- DATA PROCESSING ---
   const allIncidents = useMemo(
     () =>
@@ -388,7 +394,7 @@ export const DashboardPrefectura = () => {
         {/* KPI GRID */}
         <div
           id="pref-kpi-grid"
-          className="grid grid-cols-2 md:grid-cols-4 gap-4"
+          className="grid grid-cols-2 md:grid-cols-5 gap-4"
         >
           <HolographicKPI
             icon="group"
@@ -413,11 +419,19 @@ export const DashboardPrefectura = () => {
             delay={3}
           />
           <HolographicKPI
+            icon="inventory_2"
+            value={retainedObjectsCount.toString()}
+            label="EN CUSTODIA"
+            color="amber"
+            trend="Objetos"
+            delay={4}
+          />
+          <HolographicKPI
             icon="verified_user"
             value={students.length.toString()}
             label="MATRÍCULA TOTAL"
             color="indigo"
-            delay={4}
+            delay={5}
           />
         </div>
 


### PR DESCRIPTION
Objetos Retenidos v1 visible en tableros institucionales.

Incluye:
- KPI de objetos retenidos bajo custodia en Dashboard de Prefectura.
- Acción directa de supervisión en Dashboard de Dirección.
- Uso de funcionalidad existente de objetos retenidos, store y permisos.
- Sin cambios de base de datos.

No incluye:
- Feria.
- SASE-PLATAFORMA.
- Supabase/RLS/migrations.
- package.json.
- pnpm-lock.yaml.
- deploy manual.

Validación:
- pnpm lint PASS
- pnpm type-check PASS
- pnpm test PASS 71/71
- pnpm build PASS