### PR TITLE
fix(trabajo-social): make SOS alert honest and persistent

### DIFF
--- a/src/components/core/SOSButton.tsx
+++ b/src/components/core/SOSButton.tsx
@@ -3,9 +3,10 @@ import React, { useState } from "react";
 interface SOSButtonProps {
   compact?: boolean;
   onActivate?: () => Promise<void> | void;
+  confirmationMessage?: string;
 }
 
-export const SOSButton: React.FC<SOSButtonProps> = ({ compact = false, onActivate }) => {
+export const SOSButton: React.FC<SOSButtonProps> = ({ compact = false, onActivate, confirmationMessage }) => {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -50,7 +51,7 @@ export const SOSButton: React.FC<SOSButtonProps> = ({ compact = false, onActivat
               </div>
             </div>
             <p className="mt-5 text-sm leading-6 text-slate-200">
-              Ya notifique a Prefectura y Orientacion. Tiempo estimado: 2-5 minutos.
+              {confirmationMessage || "Alerta crítica registrada en modo local. La notificación automática institucional está en preparación."}
             </p>
             <button
               type="button"

--- a/src/components/dashboards/DashboardTrabajoSocial.tsx
+++ b/src/components/dashboards/DashboardTrabajoSocial.tsx
@@ -29,7 +29,7 @@ import {
 } from "../trabajoSocial/trabajoSocialTypes";
 
 export const DashboardTrabajoSocial = () => {
-  const { students } = useApp();
+  const { students, createEmergencyAlert, currentUserProfile } = useApp();
   const rolePermissions = PERMISOS_POR_ROL.trabajo_social;
   const baseCases = buildTrabajoSocialCases(students);
 
@@ -112,6 +112,16 @@ export const DashboardTrabajoSocial = () => {
     setLastAction("Caso devuelto a Orientacion para ajuste del plan de intervencion.");
   };
 
+  const handleSOS = async () => {
+    await createEmergencyAlert("otros", {
+      ubicacion: "Otro",
+      aula: "Trabajo Social",
+      grupo: currentUserProfile?.grupo_tutor || undefined,
+      descripcion: "Alerta critica activada desde Dashboard de Trabajo Social.",
+    });
+    setLastAction("Alerta critica registrada en el flujo institucional de emergencias.");
+  };
+
   return (
     <main className="min-h-screen flex-1 overflow-y-auto bg-slate-950 px-4 pb-10 text-white md:px-6 lg:px-8">
       <TrabajoSocialRoleHeader
@@ -120,7 +130,7 @@ export const DashboardTrabajoSocial = () => {
         criticalAlertsCount={criticalAlerts}
         onSearchChange={setSearch}
         onOpenSasito={() => setSasitoOpen((current) => !current)}
-        onSOS={() => setLastAction("SOS activado desde Trabajo Social.")}
+        onSOS={handleSOS}
       />
 
       <div className="mx-auto mt-6 grid w-full max-w-7xl grid-cols-1 gap-5 xl:grid-cols-[minmax(320px,0.85fr)_minmax(0,1.15fr)]">

--- a/src/components/trabajoSocial/TrabajoSocialRoleHeader.tsx
+++ b/src/components/trabajoSocial/TrabajoSocialRoleHeader.tsx
@@ -7,7 +7,7 @@ interface TrabajoSocialRoleHeaderProps {
   criticalAlertsCount: number;
   onSearchChange: (value: string) => void;
   onOpenSasito: () => void;
-  onSOS: () => void;
+  onSOS: () => Promise<void> | void;
 }
 
 export const TrabajoSocialRoleHeader: React.FC<TrabajoSocialRoleHeaderProps> = ({
@@ -48,7 +48,11 @@ export const TrabajoSocialRoleHeader: React.FC<TrabajoSocialRoleHeaderProps> = (
           <button type="button" onClick={onOpenSasito} className="min-h-[56px] rounded-2xl bg-orange-500/20 px-4 text-xs font-black uppercase tracking-widest text-orange-100 ring-1 ring-orange-300/30">
             Sasito operativo
           </button>
-          <SOSButton compact onActivate={onSOS} />
+          <SOSButton
+            compact
+            onActivate={onSOS}
+            confirmationMessage="Alerta crítica registrada en modo local. La notificación automática institucional está en preparación."
+          />
         </div>
 
         <label className="relative block">


### PR DESCRIPTION
Corrige el SOS de Trabajo Social para evitar éxito institucional falso.

Cambios:
- Trabajo Social usa createEmergencyAlert("otros", ...) en vez de solo setLastAction.
- El modal ya no promete notificación automática a Prefectura/Orientación.
- Mensaje honesto: alerta crítica registrada en modo local; notificación automática institucional en preparación.
- Mantiene loading/bloqueo contra doble clic.

Scope guard:
- No Supabase/RLS/migrations.
- No Feria.
- No package.json ni lockfiles.
- No otros botones P1.
- No deploy manual.

Validación:
- pnpm lint PASS con warnings preexistentes.
- pnpm type-check PASS.
- pnpm build PASS.
- pnpm test FAIL ambiental: también falla en main con Node v24.15.0 por ERR_PACKAGE_IMPORT_NOT_DEFINED #module-evaluator antes de cargar tests.