### PR TITLE
fix: prevent protocol dashboard overlap

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -755,8 +755,8 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({
           <div 
             data-sasito-target="tablero" 
             className={isExternalModule 
-              ? `h-full w-full flex-1 relative z-10 transition-[padding] duration-300 ${hasActiveEmergency ? "lg:pr-[28rem]" : ""}`
-              : `min-h-full p-4 md:p-8 animate-fade-in relative z-10 transition-[padding] duration-300 ${hasActiveEmergency ? "lg:pr-[28rem]" : ""}`
+              ? `h-full w-full flex-1 relative z-10 transition-[padding] duration-300 ${hasActiveEmergency ? "xl:pr-[28rem]" : ""}`
+              : `min-h-full p-4 md:p-8 animate-fade-in relative z-10 transition-[padding] duration-300 ${hasActiveEmergency ? "xl:pr-[28rem]" : ""}`
             }
           >
             {children}
@@ -764,7 +764,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({
         </main>
 
         {/* Sasito IA: siempre presente en todas las pantallas */}
-        <SasitoAssistant suppressAssistant={hasActiveEmergency} suppressSuggestions={suppressNonCriticalOverlays} />
+        <SasitoAssistant suppressAssistant={isTourActive || hasActiveEmergency} suppressSuggestions={suppressNonCriticalOverlays} />
         {!isDemoCleanMode && <EncuestaPulso />}
       </div>
 

--- a/src/components/emergency/EmergencyBoard.tsx
+++ b/src/components/emergency/EmergencyBoard.tsx
@@ -13,27 +13,27 @@ function minutesOpen(alert: EmergencyAlert) {
 }
 
 const EmergencyCard: React.FC<{ alert: EmergencyAlert }> = ({ alert }) => (
-  <div className="rounded-xl border border-white/8 bg-white/[0.04] p-3 text-slate-200">
-    <div className="flex items-center justify-between gap-3">
-      <p className="text-[10px] font-black uppercase tracking-widest text-white">{alert.tipo_alerta}</p>
+  <div className="min-w-0 rounded-xl border border-white/8 bg-white/[0.04] p-3 text-slate-200">
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <p className="min-w-0 truncate text-[10px] font-black uppercase tracking-widest text-white">{alert.tipo_alerta}</p>
       <span className="rounded-full bg-red-500/15 px-2 py-1 text-[9px] font-black uppercase tracking-widest text-red-200">
         N{alert.escalado_nivel ?? 0}
       </span>
     </div>
     <div className="mt-3 space-y-2 text-[10px] font-bold uppercase tracking-wide text-slate-400">
-      <p className="flex items-center gap-2"><User className="h-3 w-3" />{alert.docente_nombre}</p>
-      <p className="flex items-center gap-2"><MapPin className="h-3 w-3" />{alert.metadata?.ubicacion || alert.aula || 'N/A'}</p>
-      <p className="flex items-center gap-2"><Clock className="h-3 w-3" />{minutesOpen(alert)} min</p>
+      <p className="flex min-w-0 items-center gap-2"><User className="h-3 w-3 shrink-0" /><span className="min-w-0 truncate">{alert.docente_nombre}</span></p>
+      <p className="flex min-w-0 items-center gap-2"><MapPin className="h-3 w-3 shrink-0" /><span className="min-w-0 truncate">{alert.metadata?.ubicacion || alert.aula || 'N/A'}</span></p>
+      <p className="flex items-center gap-2"><Clock className="h-3 w-3 shrink-0" />{minutesOpen(alert)} min</p>
     </div>
   </div>
 );
 
 const Column: React.FC<ColumnConfig> = ({ title, items, accent }) => (
-  <div className="flex flex-col h-full min-h-[12rem] rounded-2xl border border-white/8 bg-[#0f1117]/92 p-3">
+  <div className="flex min-w-0 flex-col rounded-2xl border border-white/8 bg-[#0f1117]/92 p-3">
     <div className={`mb-3 rounded-xl px-3 py-2 text-[10px] font-black uppercase tracking-widest ${accent} sticky top-0 z-10 backdrop-blur-md`}>
       {title} ({items.length})
     </div>
-    <div className="flex-1 space-y-2 overflow-y-auto custom-scrollbar pr-1 max-h-[30vh] md:max-h-none">
+    <div className="max-h-[18rem] flex-1 space-y-2 overflow-y-auto pr-1 custom-scrollbar">
       {items.length === 0 ? (
         <p className="rounded-xl border border-dashed border-white/10 p-4 text-center text-[10px] font-bold uppercase tracking-widest text-slate-600">
           Sin registros
@@ -53,9 +53,8 @@ export const EmergencyBoard: React.FC<{ alerts: EmergencyAlert[] }> = ({ alerts 
   ];
 
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-3 pb-safe">
+    <div className="grid min-w-0 grid-cols-[repeat(auto-fit,minmax(min(100%,10rem),1fr))] gap-3 pb-safe">
       {columns.map((column) => <Column key={column.title} {...column} />)}
     </div>
   );
 };
-

--- a/src/components/emergency/EmergencyResponsePanel.tsx
+++ b/src/components/emergency/EmergencyResponsePanel.tsx
@@ -41,9 +41,9 @@ export const EmergencyResponsePanel: React.FC = () => {
   const showBoard = currentUserProfile?.rol === 'directivo' || currentUserProfile?.rol === 'subdireccion';
 
   return (
-    <div className="fixed top-20 right-0 z-40 w-full px-4 pointer-events-none md:right-6 md:top-24 md:w-96 md:px-0">
+    <div className="fixed inset-x-4 top-20 z-40 pointer-events-none xl:left-auto xl:right-6 xl:top-24 xl:w-[26rem]">
       {/* Indicador Compacto para Móvil */}
-      <div className="flex justify-end md:hidden">
+      <div className="flex justify-end xl:hidden">
         <motion.button
           initial={{ scale: 0.8, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
@@ -57,9 +57,9 @@ export const EmergencyResponsePanel: React.FC = () => {
       </div>
 
       {/* Panel Contenido (Board + Alertas) */}
-      <div className={`space-y-3 pointer-events-auto transition-all duration-300 ${!isExpanded ? 'hidden md:block' : 'block'}`}>
+      <div className={`min-w-0 space-y-3 pointer-events-auto transition-all duration-300 ${!isExpanded ? 'hidden xl:block' : 'block'}`}>
         {showBoard && (
-          <div className="max-h-[32vh] overflow-y-auto rounded-2xl">
+          <div className="max-h-[min(60vh,32rem)] min-w-0 overflow-y-auto overflow-x-hidden rounded-2xl">
             <EmergencyBoard alerts={activeAlerts} />
           </div>
         )}


### PR DESCRIPTION
## Resumen
- Reubica el panel completo de alertas de estado para que no invada dashboards de protocolos en breakpoints intermedios.
- Cambia el board Activas / En atención / Cerradas a grid responsive con columnas auto-fit y contenido truncado con min-w-0.
- Alinea la reserva de espacio del layout con el breakpoint donde aparece el rail de emergencias.

## Validación
- pnpm lint
- pnpm type-check
- pnpm build

No toca PR #86, Supabase/RLS/migraciones, Feria/Diagnóstico externos ni package/lockfiles.