### PR TITLE
fix(db): add post-emergency incident RPC

### DIFF
--- a/src/components/QuickRegisterModal.tsx
+++ b/src/components/QuickRegisterModal.tsx
@@ -29,6 +29,7 @@ export const QuickRegisterModal: React.FC = () => {
     students,
     groups,
     addIncident,
+    applyIncidentSideEffects,
     fetchStudents,
     currentUserRole,
     addDocumentoInstitucional,
@@ -176,14 +177,20 @@ export const QuickRegisterModal: React.FC = () => {
         p_descripcion: description,
       });
 
-      if (error || !data?.[0]?.success) {
+      const rpcResult = Array.isArray(data) ? data[0] : data;
+      if (error || !rpcResult?.success || !rpcResult?.incidencia_id) {
         console.error("Error al registrar incidencia post-emergencia", error);
         toast.error("No se pudo registrar por permisos o validación institucional.");
         return;
       }
 
+      incidentSaved = await applyIncidentSideEffects({
+        studentId: selectedStudentId,
+        type,
+        description,
+        incidentId: rpcResult.incidencia_id,
+      });
       await fetchStudents?.();
-      incidentSaved = true;
     } else {
       incidentSaved = await addIncident(selectedStudentId, type, description);
     }

--- a/src/components/QuickRegisterModal.tsx
+++ b/src/components/QuickRegisterModal.tsx
@@ -24,9 +24,12 @@ export const QuickRegisterModal: React.FC = () => {
     quickRegisterOpen,
     setQuickRegisterOpen,
     quickRegisterType,
+    quickRegisterContext,
+    setQuickRegisterContext,
     students,
     groups,
     addIncident,
+    fetchStudents,
     currentUserRole,
     addDocumentoInstitucional,
     setIsAssistantOpen,
@@ -149,6 +152,7 @@ export const QuickRegisterModal: React.FC = () => {
     return selectedGrupo ? true : false;
   });
   const visibleFilteredStudents = filteredStudents.slice(0, STUDENT_DROPDOWN_LIMIT);
+  const isPostEmergencyReport = quickRegisterContext?.source === "post_emergencia" && quickRegisterContext?.alertaId;
 
   const handleRegister = async () => {
     if (!selectedStudentId && !studentNotFound) {
@@ -163,7 +167,27 @@ export const QuickRegisterModal: React.FC = () => {
       return;
     }
 
-    const incidentSaved = await addIncident(selectedStudentId, type, description);
+    let incidentSaved = false;
+    if (isPostEmergencyReport) {
+      const { data, error } = await (supabase as any).rpc("registrar_incidencia_post_emergencia", {
+        p_alerta_id: quickRegisterContext.alertaId,
+        p_alumno_id: selectedStudentId,
+        p_tipo: type,
+        p_descripcion: description,
+      });
+
+      if (error || !data?.[0]?.success) {
+        console.error("Error al registrar incidencia post-emergencia", error);
+        toast.error("No se pudo registrar por permisos o validación institucional.");
+        return;
+      }
+
+      await fetchStudents?.();
+      incidentSaved = true;
+    } else {
+      incidentSaved = await addIncident(selectedStudentId, type, description);
+    }
+
     if (!incidentSaved) return;
 
     // Check Protocols
@@ -230,6 +254,7 @@ export const QuickRegisterModal: React.FC = () => {
     setDescription("");
     setStudentNotFound(false);
     setPendingStudentName("");
+    setQuickRegisterContext(null);
   };
 
   return (

--- a/src/components/emergency/EmergencyAlertModal.tsx
+++ b/src/components/emergency/EmergencyAlertModal.tsx
@@ -251,7 +251,10 @@ export const EmergencyAlertModal: React.FC<EmergencyAlertModalProps> = ({ onClos
                 <button
                   onClick={() => {
                     onClose();
-                    openQuickRegister(IncidentType.CONDUCTA);
+                    openQuickRegister(IncidentType.CONDUCTA, {
+                      source: "post_emergencia",
+                      alertaId: myActiveAlert.id,
+                    });
                   }}
                   className="flex-1 rounded-xl bg-blue-600 py-4 text-xs font-black uppercase tracking-widest text-white hover:bg-blue-500 shadow-lg shadow-blue-600/20 transition-all"
                 >

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -43,6 +43,7 @@ interface AppContextType {
   groups: any[];
   fetchGroups: any;
   addIncident: any;
+  applyIncidentSideEffects: any;
   markIncidentAsNotified: any;
   addJustificante: any;
   updateGrades: any;

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -57,6 +57,8 @@ interface AppContextType {
   quickRegisterOpen: any;
   setQuickRegisterOpen: any;
   quickRegisterType: any;
+  quickRegisterContext: any;
+  setQuickRegisterContext: any;
   openQuickRegister: any;
   assistantMessage: any;
   assistantSuggestion: { text: string, state?: string, actionLabel?: string, actionType?: string } | null;

--- a/src/store/slices/useStudentsSlice.ts
+++ b/src/store/slices/useStudentsSlice.ts
@@ -52,6 +52,15 @@ const PERSISTENCE_ERROR_MESSAGE = "No se pudo registrar por permisos o validaci�
 const isIncidentType = (value: unknown): value is IncidentType =>
   Object.values(IncidentType).includes(value as IncidentType);
 
+interface PersistedIncidentEffectsInput {
+  studentId: string;
+  type: IncidentType;
+  description: string;
+  incidentId: string;
+  incidentDate?: string;
+  evidence?: string[];
+}
+
 // Production: No fictional data — students are loaded from Supabase
 const INITIAL_STUDENTS: Student[] = []; // v4.1 Sync
 
@@ -71,6 +80,125 @@ export const useStudentsSlice = (
 ) => {
   const [students, setStudents] = useState<Student[]>([]);
   const [groups, setGroups] = useState<any[]>([]);
+
+  const applyIncidentSideEffects = useCallback(async ({
+    studentId,
+    type,
+    description,
+    incidentId,
+    incidentDate,
+    evidence,
+  }: PersistedIncidentEffectsInput) => {
+    const cleanDescription = String(description ?? "").trim();
+    const student = students.find((s) => s.id === studentId);
+    const reporterName = profile?.nombre_completo || profile?.nombres || user?.email || "SASE-System";
+
+    if (!student || !isIncidentType(type) || !cleanDescription || !incidentId) {
+      toast.error(PERSISTENCE_ERROR_MESSAGE);
+      return false;
+    }
+
+    const savedIncidentDate = incidentDate || new Date().toISOString();
+    const newIncidentLocal: Incident = {
+      id: incidentId,
+      studentId,
+      type,
+      description: cleanDescription,
+      date: savedIncidentDate,
+      reportedBy: currentUserRole,
+      evidence,
+      reporta: reporterName,
+      notificado_whatsapp: false,
+    };
+
+    const previousIncidents = student.incidents || [];
+    const escalationResult = evaluateEscalation(newIncidentLocal, previousIncidents);
+    const shouldDetectPattern =
+      previousIncidents.length + 1 >= 3 && student.caseState === CaseState.OBSERVADO;
+
+    setStudents((prev) =>
+      prev.map((s) => {
+        if (s.id !== studentId) return s;
+        return {
+          ...s,
+          incidents: [newIncidentLocal, ...(s.incidents || [])],
+          caseState: shouldDetectPattern ? CaseState.PATRON_DETECTADO : s.caseState,
+        };
+      }),
+    );
+
+    if (shouldDetectPattern) {
+      addNotification({
+        title: "🚨 PATRÓN DE RIESGO DETECTADO",
+        message: `El estudiante ${student.name} ha alcanzado el umbral de 3 incidencias.`,
+        type: "error",
+        targetRole: UserRole.ORIENTACION,
+        actionModule: AppModule.REPORTES,
+      });
+    }
+
+    if (type === IncidentType.RETARDO || type === IncidentType.ASISTENCIA) {
+      fetchDailyStats();
+    }
+
+    if (escalationResult?.notifyRoles) {
+      const { notifyRoles, priority, message, protocolId } = escalationResult;
+
+      notifyRoles.forEach((role: UserRole) => {
+        addNotification({
+          title:
+            priority === "CRITICAL"
+              ? "🚨 PROTOCOLO CRÍTICO"
+              : "Aviso de Seguimiento",
+          message: `${message} (Alumno: ${student.name || "N/A"})`,
+          type: priority === "CRITICAL" ? "error" : "warning",
+          targetRole: role,
+          actionModule: protocolId ? AppModule.PROTOCOLOS : AppModule.REPORTES,
+          actionData: { protocolId },
+        });
+      });
+
+      if (priority === "CRITICAL" && student.guardianInfo?.phonePrimary) {
+        const whatsappMsg = `SASE-310 ALERTA: Se ha activado un protocolo de ${message} para el alumno ${student.name}. Por favor, comuníquese con la institución.`;
+
+        sendWhatsAppNotification({
+          to: student.guardianInfo.phonePrimary,
+          message: whatsappMsg,
+          studentName: student.name,
+          incidentType: type,
+        }).then(res => {
+          if (res.success) {
+            console.log("WhatsApp enviado correctamente");
+          } else {
+            console.warn("Fallo al enviar WhatsApp:", res.error);
+          }
+        });
+      }
+
+      if (priority === "CRITICAL") {
+        toast.error(`¡ACTIVACIÓN DE PROTOCOLO! ${message}`, { duration: 6000 });
+        logAudit(
+          "CREACION",
+          `Protocolo Activado: ${message}`,
+          "incidencias",
+          newIncidentLocal.id,
+          student.name,
+        );
+      }
+    }
+
+    toast.success("Incidencia registrada institucionalmente");
+    return true;
+  }, [
+    addNotification,
+    currentUserRole,
+    fetchDailyStats,
+    logAudit,
+    profile?.nombre_completo,
+    profile?.nombres,
+    students,
+    user?.email,
+  ]);
 
   const fetchGroups = useCallback(async () => {
     if (!user) {
@@ -276,7 +404,6 @@ export const useStudentsSlice = (
     evidence?: string[],
   ) => {
     const tempId = Math.random().toString(36).substr(2, 9);
-    const reporterName = profile?.nombre_completo || profile?.nombres || user?.email || "SASE-System";
 
     try {
       const cleanDescription = String(description ?? "").trim();
@@ -299,96 +426,14 @@ export const useStudentsSlice = (
       ]);
       if (error) throw error;
 
-      const newIncidentLocal: Incident = {
-        id: tempId,
+      return await applyIncidentSideEffects({
         studentId,
         type,
         description: cleanDescription,
-        date: incidentDate,
-        reportedBy: currentUserRole,
         evidence,
-        reporta: reporterName,
-        notificado_whatsapp: false,
-      };
-
-      const previousIncidents = student.incidents || [];
-      const escalationResult = evaluateEscalation(newIncidentLocal, previousIncidents);
-      const shouldDetectPattern =
-        previousIncidents.length + 1 >= 3 && student.caseState === CaseState.OBSERVADO;
-
-      setStudents((prev) =>
-        prev.map((s) => {
-          if (s.id !== studentId) return s;
-          return {
-            ...s,
-            incidents: [newIncidentLocal, ...(s.incidents || [])],
-            caseState: shouldDetectPattern ? CaseState.PATRON_DETECTADO : s.caseState,
-          };
-        }),
-      );
-
-      if (shouldDetectPattern) {
-        addNotification({
-          title: "🚨 PATRÓN DE RIESGO DETECTADO",
-          message: `El estudiante ${student.name} ha alcanzado el umbral de 3 incidencias.`,
-          type: "error",
-          targetRole: UserRole.ORIENTACION,
-          actionModule: AppModule.REPORTES,
-        });
-      }
-
-      if (type === IncidentType.RETARDO || type === IncidentType.ASISTENCIA) {
-        fetchDailyStats();
-      }
-
-      if (escalationResult?.notifyRoles) {
-        const { notifyRoles, priority, message, protocolId } = escalationResult;
-
-        notifyRoles.forEach((role: UserRole) => {
-          addNotification({
-            title:
-              priority === "CRITICAL"
-                ? "🚨 PROTOCOLO CRÍTICO"
-                : "Aviso de Seguimiento",
-            message: `${message} (Alumno: ${student.name || "N/A"})`,
-            type: priority === "CRITICAL" ? "error" : "warning",
-            targetRole: role,
-            actionModule: protocolId ? AppModule.PROTOCOLOS : AppModule.REPORTES,
-            actionData: { protocolId },
-          });
-        });
-
-        if (priority === "CRITICAL" && student.guardianInfo?.phonePrimary) {
-          const whatsappMsg = `SASE-310 ALERTA: Se ha activado un protocolo de ${message} para el alumno ${student.name}. Por favor, comuníquese con la institución.`;
-
-          sendWhatsAppNotification({
-            to: student.guardianInfo.phonePrimary,
-            message: whatsappMsg,
-            studentName: student.name,
-            incidentType: type,
-          }).then(res => {
-            if (res.success) {
-              console.log("WhatsApp enviado correctamente");
-            } else {
-              console.warn("Fallo al enviar WhatsApp:", res.error);
-            }
-          });
-        }
-
-        if (priority === "CRITICAL") {
-          toast.error(`¡ACTIVACIÓN DE PROTOCOLO! ${message}`, { duration: 6000 });
-          logAudit(
-            "CREACION",
-            `Protocolo Activado: ${message}`,
-            "incidencias",
-            newIncidentLocal.id,
-            student.name,
-          );
-        }
-      }
-
-      toast.success("Incidencia registrada institucionalmente");
-      return true;
+        incidentId: tempId,
+        incidentDate,
+      });
     } catch (err: any) {
       console.warn("Error al guardar incidencia", err);
       toast.error(PERSISTENCE_ERROR_MESSAGE);
@@ -817,6 +862,7 @@ export const useStudentsSlice = (
     groups,
     fetchGroups,
     addIncident,
+    applyIncidentSideEffects,
     addJustificante,
     updateGrades,
     updateBapInfo,

--- a/src/store/slices/useUiSlice.ts
+++ b/src/store/slices/useUiSlice.ts
@@ -14,6 +14,7 @@ export const useUiSlice = (
 ) => {
   const [quickRegisterOpen, setQuickRegisterOpen] = useState(false);
   const [quickRegisterType, setQuickRegisterType] = useState<any>(null);
+  const [quickRegisterContext, setQuickRegisterContext] = useState<any>(null);
   const [assistantMessage, setAssistantMessage] = useState<string | null>(null);
   const [assistantSuggestion, setAssistantSuggestion] = useState<{ text: string, state?: string, actionLabel?: string, actionType?: string } | null>(null);
   const [isAssistantOpen, setIsAssistantOpen] = useState(false);
@@ -59,8 +60,9 @@ export const useUiSlice = (
     return "normal"; 
   }, [students, isAssistantOpen, assistantStatus]);
 
-  const openQuickRegister = (type?: any) => {
+  const openQuickRegister = (type?: any, context?: any) => {
     if (type) setQuickRegisterType(type);
+    setQuickRegisterContext(context || null);
     setQuickRegisterOpen(true);
   };
 
@@ -109,6 +111,8 @@ export const useUiSlice = (
     setQuickRegisterOpen,
     quickRegisterType,
     setQuickRegisterType,
+    quickRegisterContext,
+    setQuickRegisterContext,
     openQuickRegister,
     assistantMessage,
     assistantSuggestion,

--- a/supabase/migrations/20260527051018_post_emergency_incident_rpc.sql
+++ b/supabase/migrations/20260527051018_post_emergency_incident_rpc.sql
@@ -22,7 +22,10 @@ declare
   v_incidencia_id uuid;
   v_alumno_existe boolean;
   v_alumno_activo boolean := true;
-  v_has_estado_column boolean;
+  v_is_creator boolean := false;
+  v_is_emergency_requester boolean := false;
+  v_is_emergency_staff boolean := false;
+  v_can_audit boolean := false;
   v_allowed_roles text[] := array[
     'docente',
     'docente_tutor',
@@ -33,8 +36,7 @@ declare
     'orientacion',
     'trabajo_social',
     'system_admin',
-    'admin',
-    'developer'
+    'admin'
   ];
 begin
   if v_actor_id is null then
@@ -42,6 +44,11 @@ begin
   end if;
 
   v_role := lower(btrim(coalesce(public.get_my_role_text(), '')));
+  v_is_emergency_requester := private.is_emergency_requester(v_actor_id);
+
+  if not (v_role = any(v_allowed_roles) and v_is_emergency_requester) then
+    raise exception 'Rol no autorizado para registrar incidencia post-emergencia' using errcode = '42501';
+  end if;
 
   if v_descripcion = '' then
     raise exception 'La descripción no puede estar vacía' using errcode = '22023';
@@ -56,9 +63,10 @@ begin
     raise exception 'Alerta de emergencia no encontrada' using errcode = 'P0002';
   end if;
 
-  if v_alerta.docente_id is distinct from v_actor_id
-    and not (v_role = any(v_allowed_roles) and private.is_emergency_requester(v_actor_id))
-  then
+  v_is_creator := v_alerta.docente_id is not distinct from v_actor_id;
+  v_is_emergency_staff := private.is_emergency_staff(v_actor_id);
+
+  if not (v_is_creator or v_is_emergency_staff) then
     raise exception 'Rol no autorizado para registrar incidencia post-emergencia' using errcode = '42501';
   end if;
 
@@ -69,27 +77,13 @@ begin
     raise exception 'Alumno no encontrado' using errcode = '23503';
   end if;
 
-  select exists (
-    select 1
-    from information_schema.columns
-    where table_schema = 'public'
-      and table_name = 'alumnos'
-      and column_name = 'estado'
-  )
-  into v_has_estado_column;
+  select coalesce(lower(to_jsonb(a)->>'estado'), 'activo') not in ('baja', 'inactivo', 'egresado')
+  into v_alumno_activo
+  from public.alumnos a
+  where a.id = p_alumno_id;
 
-  if v_has_estado_column then
-    execute $sql$
-      select coalesce(lower(estado::text), 'activo') not in ('baja', 'inactivo', 'egresado')
-      from public.alumnos
-      where id = $1
-    $sql$
-    into v_alumno_activo
-    using p_alumno_id;
-
-    if not coalesce(v_alumno_activo, false) then
-      raise exception 'Alumno no activo' using errcode = '23503';
-    end if;
+  if not coalesce(v_alumno_activo, false) then
+    raise exception 'Alumno no activo' using errcode = '23503';
   end if;
 
   v_tipo := case
@@ -129,32 +123,76 @@ begin
   )
   returning id into v_incidencia_id;
 
-  insert into public.auditoria (
-    usuario_id,
-    rol_usuario,
-    tipo_accion,
-    descripcion_accion,
-    tabla_objetivo,
-    id_registro_objetivo,
-    new_values
-  )
-  values (
-    v_actor_id,
-    v_role,
-    'CREACION',
-    'Incidencia registrada desde flujo post_emergencia',
-    'incidencias',
-    v_incidencia_id::text,
-    jsonb_build_object(
-      'origen', 'post_emergencia',
-      'alerta_id', p_alerta_id,
-      'alumno_id', p_alumno_id,
-      'incidencia_id', v_incidencia_id,
-      'usuario_id', v_actor_id,
-      'rol', v_role,
-      'timestamp', now()
-    )
-  );
+  -- Auditoria best-effort: una diferencia de esquema no debe revertir la incidencia.
+  begin
+    select to_regclass('public.auditoria') is not null
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'usuario_id'
+      )
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'rol_usuario'
+      )
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'tipo_accion'
+      )
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'descripcion_accion'
+      )
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'tabla_objetivo'
+      )
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'id_registro_objetivo'
+      )
+      and exists (
+        select 1 from information_schema.columns
+        where table_schema = 'public' and table_name = 'auditoria' and column_name = 'new_values'
+      )
+    into v_can_audit;
+
+    if v_can_audit then
+      execute $audit$
+        insert into public.auditoria (
+          usuario_id,
+          rol_usuario,
+          tipo_accion,
+          descripcion_accion,
+          tabla_objetivo,
+          id_registro_objetivo,
+          new_values
+        )
+        values (
+          $1,
+          $2,
+          'CREACION',
+          'Incidencia registrada desde flujo post_emergencia',
+          'incidencias',
+          $3::text,
+          jsonb_build_object(
+            'origen', 'post_emergencia',
+            'alerta_id', $4,
+            'alumno_id', $5,
+            'incidencia_id', $3,
+            'usuario_id', $1,
+            'rol', $2,
+            'timestamp', now()
+          )
+        )
+      $audit$
+      using v_actor_id, v_role, v_incidencia_id, p_alerta_id, p_alumno_id;
+    else
+      raise notice 'Auditoria post_emergencia omitida por estructura no compatible';
+    end if;
+  exception
+    when others then
+      raise notice 'Auditoria post_emergencia omitida por error interno';
+  end;
 
   return query select true, v_incidencia_id;
 end;

--- a/supabase/migrations/20260527051018_post_emergency_incident_rpc.sql
+++ b/supabase/migrations/20260527051018_post_emergency_incident_rpc.sql
@@ -26,6 +26,10 @@ declare
   v_is_emergency_requester boolean := false;
   v_is_emergency_staff boolean := false;
   v_can_audit boolean := false;
+  v_profile_exists boolean := false;
+  v_profile_name text;
+  v_profile_role_text text;
+  v_profile_role public.app_role := 'docente'::public.app_role;
   v_allowed_roles text[] := array[
     'docente',
     'docente_tutor',
@@ -35,6 +39,7 @@ declare
     'medico_escolar',
     'orientacion',
     'trabajo_social',
+    'developer',
     'system_admin',
     'admin'
   ];
@@ -46,8 +51,53 @@ begin
   v_role := lower(btrim(coalesce(public.get_my_role_text(), '')));
   v_is_emergency_requester := private.is_emergency_requester(v_actor_id);
 
+  -- Developer queda permitido solo en este flujo de emergencia porque los
+  -- helpers institucionales lo consideran operador activo de emergencia.
   if not (v_role = any(v_allowed_roles) and v_is_emergency_requester) then
     raise exception 'Rol no autorizado para registrar incidencia post-emergencia' using errcode = '42501';
+  end if;
+
+  select exists(select 1 from public.profiles where id = v_actor_id)
+  into v_profile_exists;
+
+  if not v_profile_exists then
+    select
+      p.nombre_completo,
+      lower(btrim(coalesce(p.rol, p.role, 'docente')))
+    into v_profile_name, v_profile_role_text
+    from public.perfiles_usuario p
+    where p.id = v_actor_id
+    limit 1;
+
+    if v_profile_role_text is null then
+      raise exception 'Perfil institucional no encontrado para reportado_por' using errcode = '23503';
+    end if;
+
+    -- public.profiles es compatibilidad legacy y su enum no incluye developer.
+    -- El rol vigente se mantiene en perfiles_usuario; la fila legacy solo
+    -- evita que la FK de incidencias falle al guardar reportado_por.
+    v_profile_role := case v_profile_role_text
+      when 'directivo' then 'directivo'::public.app_role
+      when 'docente' then 'docente'::public.app_role
+      when 'docente_tutor' then 'docente_tutor'::public.app_role
+      when 'prefectura' then 'prefectura'::public.app_role
+      when 'orientacion' then 'orientacion'::public.app_role
+      when 'trabajo_social' then 'trabajo_social'::public.app_role
+      when 'enfermeria' then 'enfermeria'::public.app_role
+      when 'medico_escolar' then 'medico_escolar'::public.app_role
+      when 'secretaria' then 'secretaria'::public.app_role
+      when 'udeii' then 'udeii'::public.app_role
+      when 'promotora_lectura' then 'promotora_lectura'::public.app_role
+      when 'subdireccion' then 'subdireccion'::public.app_role
+      when 'admin' then 'admin'::public.app_role
+      when 'system_admin' then 'system_admin'::public.app_role
+      when 'developer' then 'system_admin'::public.app_role
+      else 'docente'::public.app_role
+    end;
+
+    insert into public.profiles (id, full_name, role)
+    values (v_actor_id, nullif(v_profile_name, ''), v_profile_role)
+    on conflict (id) do nothing;
   end if;
 
   if v_descripcion = '' then

--- a/supabase/migrations/20260527051018_post_emergency_incident_rpc.sql
+++ b/supabase/migrations/20260527051018_post_emergency_incident_rpc.sql
@@ -1,0 +1,165 @@
+-- RPC segura para registrar incidencias formales originadas desde una alerta
+-- de emergencia. No modifica la policy general de INSERT en incidencias.
+
+create or replace function public.registrar_incidencia_post_emergencia(
+  p_alerta_id uuid,
+  p_alumno_id uuid,
+  p_tipo text,
+  p_descripcion text
+)
+returns table(success boolean, incidencia_id uuid)
+language plpgsql
+security definer
+set search_path to public, private
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_role text;
+  v_descripcion text := btrim(coalesce(p_descripcion, ''));
+  v_tipo_text text := lower(btrim(coalesce(p_tipo, '')));
+  v_tipo public.tipo_incidencia;
+  v_alerta public.alertas_emergencia%rowtype;
+  v_incidencia_id uuid;
+  v_alumno_existe boolean;
+  v_alumno_activo boolean := true;
+  v_has_estado_column boolean;
+  v_allowed_roles text[] := array[
+    'docente',
+    'docente_tutor',
+    'directivo',
+    'subdireccion',
+    'prefectura',
+    'medico_escolar',
+    'orientacion',
+    'trabajo_social',
+    'system_admin',
+    'admin',
+    'developer'
+  ];
+begin
+  if v_actor_id is null then
+    raise exception 'Usuario no autenticado' using errcode = '28000';
+  end if;
+
+  v_role := lower(btrim(coalesce(public.get_my_role_text(), '')));
+
+  if v_descripcion = '' then
+    raise exception 'La descripción no puede estar vacía' using errcode = '22023';
+  end if;
+
+  select *
+  into v_alerta
+  from public.alertas_emergencia
+  where id = p_alerta_id;
+
+  if not found then
+    raise exception 'Alerta de emergencia no encontrada' using errcode = 'P0002';
+  end if;
+
+  if v_alerta.docente_id is distinct from v_actor_id
+    and not (v_role = any(v_allowed_roles) and private.is_emergency_requester(v_actor_id))
+  then
+    raise exception 'Rol no autorizado para registrar incidencia post-emergencia' using errcode = '42501';
+  end if;
+
+  select exists(select 1 from public.alumnos where id = p_alumno_id)
+  into v_alumno_existe;
+
+  if not v_alumno_existe then
+    raise exception 'Alumno no encontrado' using errcode = '23503';
+  end if;
+
+  select exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'alumnos'
+      and column_name = 'estado'
+  )
+  into v_has_estado_column;
+
+  if v_has_estado_column then
+    execute $sql$
+      select coalesce(lower(estado::text), 'activo') not in ('baja', 'inactivo', 'egresado')
+      from public.alumnos
+      where id = $1
+    $sql$
+    into v_alumno_activo
+    using p_alumno_id;
+
+    if not coalesce(v_alumno_activo, false) then
+      raise exception 'Alumno no activo' using errcode = '23503';
+    end if;
+  end if;
+
+  v_tipo := case
+    when v_tipo_text in ('retardo') then 'retardo'::public.tipo_incidencia
+    when v_tipo_text in ('conducta', 'observacion de convivencia', 'observación de convivencia') then 'conducta'::public.tipo_incidencia
+    when v_tipo_text in ('uniforme', 'falta de uniforme') then 'uniforme'::public.tipo_incidencia
+    when v_tipo_text in ('asistencia', 'asistencia / falta') then 'asistencia'::public.tipo_incidencia
+    when v_tipo_text in ('academica', 'académica', 'observacion academica', 'observación académica') then 'academica'::public.tipo_incidencia
+    when v_tipo_text in ('socioemocional', 'atencion socioemocional', 'atención socioemocional') then 'socioemocional'::public.tipo_incidencia
+    when v_tipo_text in ('salud', 'atencion medica', 'atención médica') then 'salud'::public.tipo_incidencia
+    when v_tipo_text in ('otro') then 'otro'::public.tipo_incidencia
+    else null
+  end;
+
+  if v_tipo is null then
+    begin
+      v_tipo := v_tipo_text::public.tipo_incidencia;
+    exception
+      when invalid_text_representation then
+        raise exception 'Tipo de incidencia inválido: %', p_tipo using errcode = '22P02';
+    end;
+  end if;
+
+  insert into public.incidencias (
+    alumno_id,
+    tipo,
+    descripcion,
+    reportado_por,
+    fecha
+  )
+  values (
+    p_alumno_id,
+    v_tipo,
+    v_descripcion,
+    v_actor_id,
+    now()
+  )
+  returning id into v_incidencia_id;
+
+  insert into public.auditoria (
+    usuario_id,
+    rol_usuario,
+    tipo_accion,
+    descripcion_accion,
+    tabla_objetivo,
+    id_registro_objetivo,
+    new_values
+  )
+  values (
+    v_actor_id,
+    v_role,
+    'CREACION',
+    'Incidencia registrada desde flujo post_emergencia',
+    'incidencias',
+    v_incidencia_id::text,
+    jsonb_build_object(
+      'origen', 'post_emergencia',
+      'alerta_id', p_alerta_id,
+      'alumno_id', p_alumno_id,
+      'incidencia_id', v_incidencia_id,
+      'usuario_id', v_actor_id,
+      'rol', v_role,
+      'timestamp', now()
+    )
+  );
+
+  return query select true, v_incidencia_id;
+end;
+$$;
+
+revoke all on function public.registrar_incidencia_post_emergencia(uuid, uuid, text, text) from public;
+revoke all on function public.registrar_incidencia_post_emergencia(uuid, uuid, text, text) from anon;
+grant execute on function public.registrar_incidencia_post_emergencia(uuid, uuid, text, text) to authenticated;

--- a/tests/useStudentsSlice.test.tsx
+++ b/tests/useStudentsSlice.test.tsx
@@ -29,6 +29,7 @@ vi.mock("../src/supabase/client", () => {
         nombre_completo: "Alumno Prueba",
         grupo: "3B",
         estado_semaforo: CaseState.OBSERVADO,
+        datos_tutor: { phonePrimary: "5512345678" },
         incidencias: [],
         justificantes: [],
         salud: [],
@@ -78,6 +79,7 @@ describe("useStudentsSlice addIncident", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     supabaseMocks.insert.mockResolvedValue({ error: null });
+    notificationMocks.sendWhatsAppNotification.mockResolvedValue({ success: true });
     supabaseMocks.from.mockImplementation((table: string) => {
       if (table === "grupos") {
         return {
@@ -98,6 +100,7 @@ describe("useStudentsSlice addIncident", () => {
                 nombre_completo: "Alumno Prueba",
                 grupo: "3B",
                 estado_semaforo: CaseState.OBSERVADO,
+                datos_tutor: { phonePrimary: "5512345678" },
                 incidencias: [],
                 justificantes: [],
                 salud: [],
@@ -152,5 +155,55 @@ describe("useStudentsSlice addIncident", () => {
 
     expect(supabaseMocks.insert).not.toHaveBeenCalled();
     expect(result.current.students[0].incidents).toHaveLength(0);
+  });
+
+  it("reutiliza escalamiento, notificaciones y WhatsApp tras RPC post-emergencia", async () => {
+    const { result } = renderStudentsSlice();
+    await waitFor(() => expect(result.current.students).toHaveLength(1));
+
+    let saved: boolean | undefined;
+    await act(async () => {
+      saved = await result.current.applyIncidentSideEffects({
+        studentId: "student-1",
+        type: IncidentType.CONDUCTA,
+        description: "Pelea con agresion fisica durante emergencia",
+        incidentId: "incident-db-1",
+        incidentDate: "2026-05-27T10:00:00.000Z",
+      });
+    });
+
+    expect(saved).toBe(true);
+    expect(result.current.students[0].incidents[0].id).toBe("incident-db-1");
+    expect(addNotification).toHaveBeenCalled();
+    expect(notificationMocks.sendWhatsAppNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "5512345678",
+        studentName: "Alumno Prueba",
+        incidentType: IncidentType.CONDUCTA,
+      }),
+    );
+    expect(logAudit).toHaveBeenCalledWith(
+      "CREACION",
+      expect.stringContaining("Protocolo Activado"),
+      "incidencias",
+      "incident-db-1",
+      "Alumno Prueba",
+    );
+  });
+
+  it("actualiza stats al aplicar efectos de retardo post-emergencia", async () => {
+    const { result } = renderStudentsSlice();
+    await waitFor(() => expect(result.current.students).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.applyIncidentSideEffects({
+        studentId: "student-1",
+        type: IncidentType.RETARDO,
+        description: "Ingreso tardio posterior a contencion de emergencia",
+        incidentId: "incident-db-2",
+      });
+    });
+
+    expect(fetchDailyStats).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Resumen
- Crea RPC SECURITY DEFINER public.registrar_incidencia_post_emergencia para registrar incidencias formales desde alertas de emergencia sin ampliar la policy general de INSERT en incidencias.
- Valida auth.uid(), alerta existente, creador o rol autorizado por helper de emergencia, alumno existente/activo si aplica, tipo válido y descripción no vacía.
- Registra auditoría con origen post_emergencia y enlaza alerta, alumno, incidencia, usuario, rol y timestamp.
- Ajusta el registro rápido para usar la RPC solo cuando viene del flujo post-emergencia; el addIncident normal queda intacto.

## Validación
- pnpm lint
- pnpm type-check
- pnpm build
- pnpm test
- bash scripts/audit-migrations.sh
- supabase db lint --local

## Notas
- No se amplió la policy general de INSERT en incidencias.
- supabase db lint --local conserva errores existentes en funciones Feria por public.progreso_recorrido faltante; no se tocaron por estar fuera de alcance.
- No deploy manual.