### PR TITLE
fix(security): prevent role and permissions self-escalation via RLS

### DIFF
--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -29,6 +29,8 @@ Este documento detalla las pruebas de seguridad para verificar que los usuarios 
 | `perfiles_usuario` | `blocked_until` | Bloqueo temporal |
 | `perfiles_usuario` | `grupo_tutor` | Scope de grupo para tokens |
 | `perfiles_usuario` | `grupos` | Scope de grupos para tokens |
+| `perfiles_usuario` | `estado_cuenta` | Estado de la cuenta |
+| `perfiles_usuario` | `risk_score` | Puntaje de riesgo automático |
 | `profiles` | `role` | Rol en tabla legacy |
 
 ## Campos permitidos (self-update PERMITIDO)
@@ -125,10 +127,12 @@ async function main() {
     { name: "matricula_sase", table: "perfiles_usuario", payload: { matricula_sase: "HACK-001" }, expectBlocked: true },
     { name: "email", table: "perfiles_usuario", payload: { email: "hacked@evil.com" }, expectBlocked: true },
     { name: "role (legacy)", table: "perfiles_usuario", payload: { role: "directivo" }, expectBlocked: true },
-    { name: "seguridad_status", table: "perfiles_usuario", payload: { seguridad_status: "limpio" }, expectBlocked: true },
+    { name: "seguridad_status", table: "perfiles_usuario", payload: { seguridad_status: "active" }, expectBlocked: true },
     { name: "blocked_until → null", table: "perfiles_usuario", payload: { blocked_until: null }, expectBlocked: true },
     { name: "grupo_tutor", table: "perfiles_usuario", payload: { grupo_tutor: "admin-group" }, expectBlocked: true },
     { name: "grupos", table: "perfiles_usuario", payload: { grupos: ["all-access"] }, expectBlocked: true },
+    { name: "estado_cuenta", table: "perfiles_usuario", payload: { estado_cuenta: "active" }, expectBlocked: true },
+    { name: "risk_score", table: "perfiles_usuario", payload: { risk_score: 0 }, expectBlocked: true },
   ];
 
   // Campo que DEBE ser bloqueado en profiles (tabla legacy)
@@ -232,14 +236,14 @@ curl -s -X PATCH \
 
 # Resultado esperado: [] o error 40x
 
-# Intentar cambiar seguridad_status
+# Intentar cambiar seguridad_status (usando un valor válido de constraint 'active' para que el error provenga del RLS y no de una constraint de dominio)
 curl -s -X PATCH \
   "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${USER_ID}" \
   -H "apikey: ${SUPABASE_ANON_KEY}" \
   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d '{"seguridad_status": "limpio"}'
+  -d '{"seguridad_status": "active"}'
 
 # Resultado esperado: [] o error 40x
 ```
@@ -273,6 +277,8 @@ curl -s -X PATCH \
 | `PATCH blocked_until=...` | `[]` vacío o HTTP 403/400 |
 | `PATCH grupo_tutor=...` | `[]` vacío o HTTP 403/400 |
 | `PATCH grupos=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH estado_cuenta=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH risk_score=...` | `[]` vacío o HTTP 403/400 |
 | `PATCH nombre_completo=...` | Registro actualizado ✅ |
 | `PATCH telefono=...` | Registro actualizado ✅ |
 | `PATCH preferencias_dashboard=...` | Registro actualizado ✅ |
@@ -328,7 +334,7 @@ BEGIN;
 
   -- ── Prueba 3: Intentar modificar seguridad_status (DEBE FALLAR) ──
   UPDATE public.perfiles_usuario
-  SET seguridad_status = 'limpio'
+  SET seguridad_status = 'active'
   WHERE id = '<uuid-real-del-usuario-qa>';
   -- Esperado: 0 filas afectadas
 

--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -1,155 +1,64 @@
-# Prueba Manual: Prevención de Autoescalamiento de Roles
+# Runbook de Pruebas: Prevención de Autoescalamiento de Roles
 
-**Migración:** `20260606150001_prevent_role_self_escalation.sql`
-**Fecha:** 2026-06-06
-**Tester:**
+Este documento detalla la auditoría de seguridad y las pruebas para verificar que los usuarios autenticados no puedan realizar autoescalamiento de roles, permisos o alcances en la base de datos de SASE.
 
----
+## Casos de Prueba
 
-## Prerrequisitos
+### Caso 1: Actualización de `rol` en `perfiles_usuario` (Debe fallar)
+* **Actor:** Usuario autenticado (ej: docente).
+* **Acción:** Intentar cambiar su rol a `admin` o `directivo`.
+* **Comando SQL de prueba:**
+  ```sql
+  -- Simular rol 'docente' con ID de prueba
+  SET local role authenticated;
+  SET local request.jwt.claim.sub = 'user-uuid-here';
+  
+  -- Intentar actualizar
+  UPDATE public.perfiles_usuario 
+  SET rol = 'admin' 
+  WHERE id = 'user-uuid-here';
+  -- Resultado esperado: Violación de política RLS o 0 filas afectadas.
+  ```
 
-1. Tener dos cuentas:
-   - **Usuario A**: rol `docente` / `docente_tutor`
-   - **Usuario B**: rol `directivo` / `system_admin` (cuenta de administración)
-2. Conocer el `id` de ambas cuentas (UUID de `auth.users`).
-3. Tener acceso a `supabase` SQL Editor (o psql) con `service_role` para verificar datos.
-4. Tener acceso autenticado desde la aplicación (frontend) para las pruebas de interfaz.
+### Caso 2: Actualización de `permisos` en `perfiles_usuario` (Debe fallar)
+* **Actor:** Usuario autenticado.
+* **Acción:** Intentar cambiar el JSONB de `permisos`.
+* **Comando SQL de prueba:**
+  ```sql
+  UPDATE public.perfiles_usuario 
+  SET permisos = '{"all": true}'::jsonb 
+  WHERE id = 'user-uuid-here';
+  -- Resultado esperado: Bloqueado por RLS.
+  ```
 
----
+### Caso 3: Actualización de `alcances` en `perfiles_usuario` (Debe fallar)
+* **Actor:** Usuario autenticado.
+* **Acción:** Intentar cambiar el JSONB de `alcances`.
+* **Comando SQL de prueba:**
+  ```sql
+  UPDATE public.perfiles_usuario 
+  SET alcances = '{"global": true}'::jsonb 
+  WHERE id = 'user-uuid-here';
+  -- Resultado esperado: Bloqueado por RLS.
+  ```
 
-## Caso 1: Usuario normal intenta actualizar su propio rol
+### Caso 4: Actualización de `role` en `profiles` (Debe fallar)
+* **Actor:** Usuario autenticado.
+* **Acción:** Intentar cambiar `role` en la tabla legacy `profiles`.
+* **Comando SQL de prueba:**
+  ```sql
+  UPDATE public.profiles 
+  SET role = 'directivo'::app_role 
+  WHERE id = 'user-uuid-here';
+  -- Resultado esperado: Bloqueado por RLS.
+  ```
 
-### Desde SQL Editor (simula cliente autenticado)
+### Caso 5: Lectura de perfil (Debe permitirse)
+* **Actor:** Usuario autenticado.
+* **Acción:** El AuthProvider inicia sesión y lee el rol y datos del perfil mediante `SELECT`.
+* **Resultado esperado:** Éxito. Lectura de su propio perfil completamente habilitada.
 
-```sql
--- Autenticarse como Usuario A (docente)
--- Esto debe FALLAR con error "new row violates row-level security policy"
-UPDATE public.perfiles_usuario
-SET rol = 'system_admin'
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** `ERROR: new row violates row-level security policy`
-
-### Desde la aplicación frontend
-
-1. Inicia sesión como Usuario A.
-2. Abre la consola del navegador (F12 → Network).
-3. Ejecuta desde la consola:
-   ```js
-   const { data, error } = await supabase
-     .from('perfiles_usuario')
-     .update({ rol: 'system_admin' })
-     .eq('id', supabase.auth.user().id);
-   console.log('Error:', error);
-   ```
-4. **Resultado esperado:** `error` no es nulo, `data` es nulo.
-
----
-
-## Caso 2: Usuario normal intenta actualizar sus permisos
-
-```sql
-UPDATE public.perfiles_usuario
-SET permisos = '{"can_approve_staff": true}'
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** `ERROR: new row violates row-level security policy`
-
----
-
-## Caso 3: Usuario normal intenta actualizar sus alcances
-
-```sql
-UPDATE public.perfiles_usuario
-SET alcances = '{"can_view_audit": true}'
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** `ERROR: new row violates row-level security policy`
-
----
-
-## Caso 4: AuthProvider sigue pudiendo leer el rol
-
-```sql
--- Simula SELECT que hace AuthProvider
-SELECT id, rol, permisos, alcances
-FROM public.perfiles_usuario
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** Debe devolver la fila completa sin error.
-
-Desde la app: Inicia sesión como Usuario A y verifica que la app carga correctamente y muestra el dashboard correspondiente a `docente`.
-
----
-
-## Caso 5: Usuario administrativo autorizado gestiona roles (flujo permitido)
-
-Los roles sensibles deben actualizarse SOLO mediante Edge Functions que usan `service_role` (bypassean RLS):
-
-```sql
--- Esto solo funciona con service_role, no desde cliente
-UPDATE public.perfiles_usuario
-SET rol = 'directivo'
-WHERE id = '<uuid-usuario-b>';
-```
-
-**Resultado esperado:** Con `service_role`: exitoso. Desde cliente: error RLS.
-
----
-
-## Caso 6: Usuario normal actualiza campos permitidos
-
-```sql
--- Esto DEBE funcionar (campos no protegidos)
-UPDATE public.perfiles_usuario
-SET nombre_completo = 'Nuevo Nombre',
-    telefono = '5512345678',
-    preferencias_dashboard = '{"avatar_url": "https://..."}'
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** Éxito. Verificar con SELECT que los cambios persisten.
-
----
-
-## Caso 7: Profiles — usuario normal no puede cambiar su role
-
-```sql
-UPDATE public.profiles
-SET role = 'directivo'
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** `ERROR: new row violates row-level security policy`
-
-```sql
--- Sí debe poder actualizar full_name
-UPDATE public.profiles
-SET full_name = 'Nombre Visible'
-WHERE id = '<uuid-usuario-a>';
-```
-
-**Resultado esperado:** Éxito.
-
----
-
-## Verificación post-prueba
-
-```sql
--- Restaurar datos originales si es necesario
--- (solo con service_role)
-```
-
-## Checklist
-
-- [ ] Caso 1: rol propio bloqueado
-- [ ] Caso 2: permisos propios bloqueados
-- [ ] Caso 3: alcances propios bloqueados
-- [ ] Caso 4: SELECT de AuthProvider funciona
-- [ ] Caso 5: service_role aún puede gestionar roles
-- [ ] Caso 6: campos permitidos (nombre, teléfono) sí se actualizan
-- [ ] Caso 7: profiles.role bloqueado
+### Caso 6: Modificación por servicio administrativo (Debe permitirse)
+* **Actor:** Servidor / Edge Functions usando `service_role`.
+* **Acción:** Crear o aprobar personal modificando roles/permisos.
+* **Resultado esperado:** Éxito. El token `service_role` evade RLS por completo.

--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -199,18 +199,28 @@ npx tsx scripts/test-rls-self-escalation.ts
 
 Este método usa la API REST (PostgREST) de Supabase directamente con `curl`. Útil para validación rápida sin escribir código.
 
+> **Nota:** Este script asume que tienes `jq` instalado en tu sistema para extraer el token y el ID del JSON de respuesta. Si no tienes `jq`, deberás extraer estos valores manualmente de la respuesta.
+
 ### 1. Obtener un token de usuario autenticado
 
 ```bash
 # Login con usuario QA (usar anon key, NUNCA service_role)
-ACCESS_TOKEN=$(curl -s -X POST \
+LOGIN_RESPONSE=$(curl -s -X POST \
   "${SUPABASE_URL}/auth/v1/token?grant_type=password" \
   -H "apikey: ${SUPABASE_ANON_KEY}" \
   -H "Content-Type: application/json" \
-  -d "{\"email\": \"${TEST_EMAIL}\", \"password\": \"${TEST_PASSWORD}\"}" \
-  | jq -r '.access_token')
+  -d "{\"email\": \"${TEST_EMAIL}\", \"password\": \"${TEST_PASSWORD}\"}")
 
-echo "Token: ${ACCESS_TOKEN:0:20}..."
+ACCESS_TOKEN=$(echo "$LOGIN_RESPONSE" | jq -r '.access_token')
+USER_ID=$(echo "$LOGIN_RESPONSE" | jq -r '.user.id')
+
+# Validaciones defensivas para asegurar la prueba
+test -n "$ACCESS_TOKEN" || { echo "❌ Falta ACCESS_TOKEN"; exit 1; }
+test "$ACCESS_TOKEN" != "null" || { echo "❌ ACCESS_TOKEN es null"; exit 1; }
+test -n "$USER_ID" || { echo "❌ Falta USER_ID"; exit 1; }
+test "$USER_ID" != "null" || { echo "❌ USER_ID es null"; exit 1; }
+
+echo "Testing QA user id: $USER_ID"
 ```
 
 ### 2. Intentar self-escalation (DEBE fallar)

--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -128,7 +128,7 @@ async function main() {
     { name: "email", table: "perfiles_usuario", payload: { email: "hacked@evil.com" }, expectBlocked: true },
     { name: "role (legacy)", table: "perfiles_usuario", payload: { role: "directivo" }, expectBlocked: true },
     { name: "seguridad_status", table: "perfiles_usuario", payload: { seguridad_status: "active" }, expectBlocked: true },
-    { name: "blocked_until → null", table: "perfiles_usuario", payload: { blocked_until: null }, expectBlocked: true },
+    { name: "blocked_until → 2099", table: "perfiles_usuario", payload: { blocked_until: "2099-01-01T00:00:00.000Z" }, expectBlocked: true }, // Se usa un valor futuro distinto al actual para probar que realmente está congelado (NULL a NULL no lo probaría)
     { name: "grupo_tutor", table: "perfiles_usuario", payload: { grupo_tutor: "admin-group" }, expectBlocked: true },
     { name: "grupos", table: "perfiles_usuario", payload: { grupos: ["all-access"] }, expectBlocked: true },
     { name: "estado_cuenta", table: "perfiles_usuario", payload: { estado_cuenta: "active" }, expectBlocked: true },

--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -1,64 +1,447 @@
 # Runbook de Pruebas: Prevención de Autoescalamiento de Roles
 
-Este documento detalla la auditoría de seguridad y las pruebas para verificar que los usuarios autenticados no puedan realizar autoescalamiento de roles, permisos o alcances en la base de datos de SASE.
+Este documento detalla las pruebas de seguridad para verificar que los usuarios autenticados **no puedan** modificar campos sensibles de su propio perfil vía self-update. Las políticas RLS `WITH CHECK` deben bloquear cualquier intento de autoescalamiento.
 
-## Casos de Prueba
+> [!CAUTION]
+> **NUNCA uses Supabase SQL Editor ni psql con conexión `service_role` para validar RLS.**
+>
+> Las conexiones con `service_role` (incluido el SQL Editor del dashboard de Supabase) operan con privilegios de superusuario y **evaden completamente RLS**. Cualquier prueba ejecutada así dará resultados falsos — los UPDATE parecerán exitosos incluso si las políticas están correctas.
+>
+> Usa **siempre** un cliente autenticado real (Métodos A o B) o una sesión SQL configurada correctamente (Método C).
 
-### Caso 1: Actualización de `rol` en `perfiles_usuario` (Debe fallar)
-* **Actor:** Usuario autenticado (ej: docente).
-* **Acción:** Intentar cambiar su rol a `admin` o `directivo`.
-* **Comando SQL de prueba:**
-  ```sql
-  -- Simular rol 'docente' con ID de prueba
-  SET local role authenticated;
-  SET local request.jwt.claim.sub = 'user-uuid-here';
-  
-  -- Intentar actualizar
-  UPDATE public.perfiles_usuario 
-  SET rol = 'admin' 
-  WHERE id = 'user-uuid-here';
-  -- Resultado esperado: Violación de política RLS o 0 filas afectadas.
-  ```
+## Entorno de prueba
 
-### Caso 2: Actualización de `permisos` en `perfiles_usuario` (Debe fallar)
-* **Actor:** Usuario autenticado.
-* **Acción:** Intentar cambiar el JSONB de `permisos`.
-* **Comando SQL de prueba:**
-  ```sql
-  UPDATE public.perfiles_usuario 
-  SET permisos = '{"all": true}'::jsonb 
-  WHERE id = 'user-uuid-here';
-  -- Resultado esperado: Bloqueado por RLS.
-  ```
+- **Entorno:** Local (`supabase start`) o staging. **NUNCA producción.**
+- **Usuario de prueba:** Crear un usuario QA desechable con rol `docente` o `estudiante`.
+- **Credenciales:** Usar `anon` key + sesión de usuario autenticado (nunca `service_role` key).
 
-### Caso 3: Actualización de `alcances` en `perfiles_usuario` (Debe fallar)
-* **Actor:** Usuario autenticado.
-* **Acción:** Intentar cambiar el JSONB de `alcances`.
-* **Comando SQL de prueba:**
-  ```sql
-  UPDATE public.perfiles_usuario 
-  SET alcances = '{"global": true}'::jsonb 
-  WHERE id = 'user-uuid-here';
-  -- Resultado esperado: Bloqueado por RLS.
-  ```
+## Campos protegidos (self-update PROHIBIDO)
 
-### Caso 4: Actualización de `role` en `profiles` (Debe fallar)
-* **Actor:** Usuario autenticado.
-* **Acción:** Intentar cambiar `role` en la tabla legacy `profiles`.
-* **Comando SQL de prueba:**
-  ```sql
-  UPDATE public.profiles 
-  SET role = 'directivo'::app_role 
-  WHERE id = 'user-uuid-here';
-  -- Resultado esperado: Bloqueado por RLS.
-  ```
+| Tabla | Campo | Razón |
+|-------|-------|-------|
+| `perfiles_usuario` | `rol` | Escalamiento de privilegios |
+| `perfiles_usuario` | `permisos` | Modificación de permisos JSONB |
+| `perfiles_usuario` | `alcances` | Modificación de alcances JSONB |
+| `perfiles_usuario` | `matricula_sase` | Identidad institucional |
+| `perfiles_usuario` | `email` | Identidad |
+| `perfiles_usuario` | `role` | Campo legacy de rol |
+| `perfiles_usuario` | `seguridad_status` | Bloqueo de seguridad |
+| `perfiles_usuario` | `blocked_until` | Bloqueo temporal |
+| `perfiles_usuario` | `grupo_tutor` | Scope de grupo para tokens |
+| `perfiles_usuario` | `grupos` | Scope de grupos para tokens |
+| `profiles` | `role` | Rol en tabla legacy |
 
-### Caso 5: Lectura de perfil (Debe permitirse)
-* **Actor:** Usuario autenticado.
-* **Acción:** El AuthProvider inicia sesión y lee el rol y datos del perfil mediante `SELECT`.
-* **Resultado esperado:** Éxito. Lectura de su propio perfil completamente habilitada.
+## Campos permitidos (self-update PERMITIDO)
 
-### Caso 6: Modificación por servicio administrativo (Debe permitirse)
-* **Actor:** Servidor / Edge Functions usando `service_role`.
-* **Acción:** Crear o aprobar personal modificando roles/permisos.
-* **Resultado esperado:** Éxito. El token `service_role` evade RLS por completo.
+| Tabla | Campo |
+|-------|-------|
+| `perfiles_usuario` | `nombre_completo` |
+| `perfiles_usuario` | `telefono` |
+| `perfiles_usuario` | `preferencias_dashboard` |
+
+---
+
+## Método A: Supabase JS Client (Recomendado)
+
+Este método usa el cliente oficial de Supabase con la `anon` key y una sesión real de usuario autenticado. Es la forma más fiel de simular lo que un usuario real puede hacer desde el frontend.
+
+### Prerequisitos
+
+```bash
+# En el directorio del proyecto
+npm install @supabase/supabase-js
+# O usar el cliente ya instalado en el proyecto
+```
+
+### Script de prueba
+
+Crear archivo `scripts/test-rls-self-escalation.ts`:
+
+```typescript
+import { createClient } from "@supabase/supabase-js";
+
+// ── Configuración ──────────────────────────────────────────────
+// Usar SIEMPRE la anon key, nunca service_role
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY ?? "<anon-key-local>";
+
+// Credenciales del usuario QA de prueba (NO admin)
+const TEST_EMAIL = "qa-test-docente@sase-test.local";
+const TEST_PASSWORD = "TestPassword123!";
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+// ── Helpers ────────────────────────────────────────────────────
+async function signIn() {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: TEST_EMAIL,
+    password: TEST_PASSWORD,
+  });
+  if (error) throw new Error(`Auth failed: ${error.message}`);
+  console.log(`✅ Autenticado como: ${data.user.email} (${data.user.id})`);
+  return data.user.id;
+}
+
+interface TestCase {
+  name: string;
+  table: string;
+  payload: Record<string, unknown>;
+  expectBlocked: boolean;
+}
+
+async function runTest(tc: TestCase, userId: string) {
+  const { data, error } = await supabase
+    .from(tc.table)
+    .update(tc.payload)
+    .eq("id", userId)
+    .select();
+
+  const blocked = !!error || !data || data.length === 0;
+  const pass = blocked === tc.expectBlocked;
+  const icon = pass ? "✅" : "❌";
+  const status = tc.expectBlocked ? "BLOQUEADO" : "PERMITIDO";
+
+  console.log(`${icon} ${tc.name}: ${status}`);
+  if (error) console.log(`   Error: ${error.message} (code: ${error.code})`);
+  if (!pass) {
+    console.error(`   ⚠️  FALLA DE SEGURIDAD: esperaba ${status} pero no fue así`);
+  }
+  return pass;
+}
+
+// ── Casos de prueba ────────────────────────────────────────────
+async function main() {
+  console.log("═══════════════════════════════════════════════════");
+  console.log("  RLS Self-Escalation Prevention Test Suite");
+  console.log("═══════════════════════════════════════════════════\n");
+
+  const userId = await signIn();
+
+  // Campos que DEBEN ser bloqueados en perfiles_usuario
+  const blockedFields: TestCase[] = [
+    { name: "rol → admin", table: "perfiles_usuario", payload: { rol: "admin" }, expectBlocked: true },
+    { name: "permisos → all:true", table: "perfiles_usuario", payload: { permisos: { all: true } }, expectBlocked: true },
+    { name: "alcances → global:true", table: "perfiles_usuario", payload: { alcances: { global: true } }, expectBlocked: true },
+    { name: "matricula_sase", table: "perfiles_usuario", payload: { matricula_sase: "HACK-001" }, expectBlocked: true },
+    { name: "email", table: "perfiles_usuario", payload: { email: "hacked@evil.com" }, expectBlocked: true },
+    { name: "role (legacy)", table: "perfiles_usuario", payload: { role: "directivo" }, expectBlocked: true },
+    { name: "seguridad_status", table: "perfiles_usuario", payload: { seguridad_status: "limpio" }, expectBlocked: true },
+    { name: "blocked_until → null", table: "perfiles_usuario", payload: { blocked_until: null }, expectBlocked: true },
+    { name: "grupo_tutor", table: "perfiles_usuario", payload: { grupo_tutor: "admin-group" }, expectBlocked: true },
+    { name: "grupos", table: "perfiles_usuario", payload: { grupos: ["all-access"] }, expectBlocked: true },
+  ];
+
+  // Campo que DEBE ser bloqueado en profiles (tabla legacy)
+  const blockedLegacy: TestCase[] = [
+    { name: "profiles.role → directivo", table: "profiles", payload: { role: "directivo" }, expectBlocked: true },
+  ];
+
+  // Campos que DEBEN ser permitidos
+  const allowedFields: TestCase[] = [
+    { name: "nombre_completo", table: "perfiles_usuario", payload: { nombre_completo: "QA Test User Updated" }, expectBlocked: false },
+    { name: "telefono", table: "perfiles_usuario", payload: { telefono: "+52 555 000 0000" }, expectBlocked: false },
+    { name: "preferencias_dashboard", table: "perfiles_usuario", payload: { preferencias_dashboard: { theme: "dark" } }, expectBlocked: false },
+  ];
+
+  console.log("\n── Campos BLOQUEADOS (perfiles_usuario) ──\n");
+  let allPass = true;
+  for (const tc of blockedFields) {
+    const pass = await runTest(tc, userId);
+    if (!pass) allPass = false;
+  }
+
+  console.log("\n── Campos BLOQUEADOS (profiles legacy) ──\n");
+  for (const tc of blockedLegacy) {
+    const pass = await runTest(tc, userId);
+    if (!pass) allPass = false;
+  }
+
+  console.log("\n── Campos PERMITIDOS ──\n");
+  for (const tc of allowedFields) {
+    const pass = await runTest(tc, userId);
+    if (!pass) allPass = false;
+  }
+
+  console.log("\n═══════════════════════════════════════════════════");
+  console.log(allPass ? "✅ TODAS LAS PRUEBAS PASARON" : "❌ HAY FALLAS DE SEGURIDAD");
+  console.log("═══════════════════════════════════════════════════\n");
+
+  await supabase.auth.signOut();
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch(console.error);
+```
+
+### Ejecución
+
+```bash
+# Desde el directorio del proyecto con Supabase local corriendo
+npx tsx scripts/test-rls-self-escalation.ts
+```
+
+### Resultados esperados
+
+- Todos los campos de la sección "BLOQUEADOS" deben mostrar `✅ BLOQUEADO`.
+- Todos los campos de la sección "PERMITIDOS" deben mostrar `✅ PERMITIDO`.
+- Si algún campo bloqueado muestra `❌`, hay una **falla de seguridad crítica**.
+
+---
+
+## Método B: curl / REST API con Bearer Token
+
+Este método usa la API REST (PostgREST) de Supabase directamente con `curl`. Útil para validación rápida sin escribir código.
+
+### 1. Obtener un token de usuario autenticado
+
+```bash
+# Login con usuario QA (usar anon key, NUNCA service_role)
+ACCESS_TOKEN=$(curl -s -X POST \
+  "${SUPABASE_URL}/auth/v1/token?grant_type=password" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\": \"${TEST_EMAIL}\", \"password\": \"${TEST_PASSWORD}\"}" \
+  | jq -r '.access_token')
+
+echo "Token: ${ACCESS_TOKEN:0:20}..."
+```
+
+### 2. Intentar self-escalation (DEBE fallar)
+
+```bash
+# Intentar cambiar rol a admin — DEBE retornar error o 0 filas
+curl -s -X PATCH \
+  "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${USER_ID}" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{"rol": "admin"}'
+
+# Resultado esperado: [] (array vacío) o error 40x
+# Si retorna el registro actualizado con rol=admin → FALLA DE SEGURIDAD
+
+# Intentar cambiar permisos
+curl -s -X PATCH \
+  "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${USER_ID}" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{"permisos": {"all": true}}'
+
+# Resultado esperado: [] o error 40x
+
+# Intentar cambiar seguridad_status
+curl -s -X PATCH \
+  "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${USER_ID}" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{"seguridad_status": "limpio"}'
+
+# Resultado esperado: [] o error 40x
+```
+
+### 3. Verificar que campos permitidos SÍ funcionan (DEBE tener éxito)
+
+```bash
+# Actualizar nombre_completo — DEBE retornar el registro actualizado
+curl -s -X PATCH \
+  "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${USER_ID}" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{"nombre_completo": "QA Test User Updated"}'
+
+# Resultado esperado: el registro con nombre_completo actualizado
+```
+
+### Resultados esperados
+
+| Operación | Resultado esperado |
+|-----------|-------------------|
+| `PATCH rol=admin` | `[]` vacío o HTTP 403/400 |
+| `PATCH permisos={...}` | `[]` vacío o HTTP 403/400 |
+| `PATCH alcances={...}` | `[]` vacío o HTTP 403/400 |
+| `PATCH matricula_sase=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH email=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH role=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH seguridad_status=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH blocked_until=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH grupo_tutor=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH grupos=...` | `[]` vacío o HTTP 403/400 |
+| `PATCH nombre_completo=...` | Registro actualizado ✅ |
+| `PATCH telefono=...` | Registro actualizado ✅ |
+| `PATCH preferencias_dashboard=...` | Registro actualizado ✅ |
+
+---
+
+## Método C: SQL con sesión autenticada correcta
+
+> [!WARNING]
+> Este método solo es válido si configuras la sesión correctamente con `set_config`. **NO uses `SET local role authenticated`** en SQL Editor de Supabase — eso NO simula RLS correctamente porque la conexión subyacente sigue siendo `service_role`.
+
+Si necesitas usar SQL directo (por ejemplo, en `psql` conectado al puerto local de Supabase), debes configurar las claims JWT manualmente usando `set_config` dentro de una transacción:
+
+```sql
+-- ═══════════════════════════════════════════════════════════════
+-- IMPORTANTE: Ejecutar contra la base de datos LOCAL (puerto 54322)
+-- NUNCA contra producción ni con credenciales service_role del dashboard
+-- ═══════════════════════════════════════════════════════════════
+
+-- Conectar como usuario con privilegios limitados
+-- psql postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+BEGIN;
+
+  -- 1. Cambiar al rol 'authenticated' (simula conexión PostgREST)
+  SET LOCAL ROLE authenticated;
+
+  -- 2. Configurar claims JWT del usuario de prueba
+  --    IMPORTANTE: usar el UUID REAL del usuario QA de prueba
+  SELECT set_config('request.jwt.claims', json_build_object(
+    'sub', '<uuid-real-del-usuario-qa>',
+    'role', 'authenticated',
+    'email', 'qa-test-docente@sase-test.local',
+    'aud', 'authenticated'
+  )::text, true);
+
+  -- También configurar el claim individual (algunas policies lo leen así)
+  SELECT set_config('request.jwt.claim.sub', '<uuid-real-del-usuario-qa>', true);
+  SELECT set_config('request.jwt.claim.email', 'qa-test-docente@sase-test.local', true);
+  SELECT set_config('request.jwt.claim.role', 'authenticated', true);
+
+  -- ── Prueba 1: Intentar autoescalamiento de rol (DEBE FALLAR) ──
+  UPDATE public.perfiles_usuario
+  SET rol = 'admin'
+  WHERE id = '<uuid-real-del-usuario-qa>';
+  -- Esperado: 0 filas afectadas (la política WITH CHECK lo rechaza)
+
+  -- ── Prueba 2: Intentar modificar permisos (DEBE FALLAR) ──
+  UPDATE public.perfiles_usuario
+  SET permisos = '{"all": true}'::jsonb
+  WHERE id = '<uuid-real-del-usuario-qa>';
+  -- Esperado: 0 filas afectadas
+
+  -- ── Prueba 3: Intentar modificar seguridad_status (DEBE FALLAR) ──
+  UPDATE public.perfiles_usuario
+  SET seguridad_status = 'limpio'
+  WHERE id = '<uuid-real-del-usuario-qa>';
+  -- Esperado: 0 filas afectadas
+
+  -- ── Prueba 4: Modificar nombre_completo (DEBE TENER ÉXITO) ──
+  UPDATE public.perfiles_usuario
+  SET nombre_completo = 'QA Test User SQL'
+  WHERE id = '<uuid-real-del-usuario-qa>';
+  -- Esperado: 1 fila afectada ✅
+
+  -- Verificar estado final
+  SELECT id, rol, nombre_completo, seguridad_status
+  FROM public.perfiles_usuario
+  WHERE id = '<uuid-real-del-usuario-qa>';
+
+ROLLBACK;  -- Revertir todos los cambios de prueba
+```
+
+### ¿Por qué `set_config` y no `SET local`?
+
+| Aspecto | `SET local request.jwt.claim.sub` | `set_config('request.jwt.claims', ...)` |
+|---------|-----------------------------------|---------------------------------------|
+| Configura claims completas | ❌ Solo un claim | ✅ Objeto JSON completo |
+| Compatible con PostgREST | Parcial | ✅ Sí |
+| Funciona en SQL Editor dashboard | ❌ La conexión sigue siendo superuser | ❌ Mismo problema |
+| Funciona en psql local | ✅ Con `SET LOCAL ROLE` | ✅ Con `SET LOCAL ROLE` |
+
+> [!IMPORTANT]
+> El método SQL **solo es confiable desde psql conectado al puerto local** (`54322`). El SQL Editor del dashboard de Supabase usa una conexión `service_role` que evade RLS sin importar qué `SET ROLE` ejecutes. **Para validación autoritativa, usa siempre el Método A o B.**
+
+---
+
+## Crear usuario QA de prueba
+
+Antes de ejecutar cualquier test, necesitas un usuario QA desechable:
+
+```bash
+# Crear usuario QA en Supabase local
+curl -s -X POST \
+  "${SUPABASE_URL}/auth/v1/signup" \
+  -H "apikey: ${SUPABASE_ANON_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "qa-test-docente@sase-test.local",
+    "password": "TestPassword123!",
+    "data": { "nombre_completo": "QA Test Docente" }
+  }'
+```
+
+Luego asignar un rol no-admin con `service_role` (esto sí es válido para setup):
+
+```bash
+# Asignar rol docente al usuario QA (usar service_role solo para SETUP)
+curl -s -X PATCH \
+  "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${QA_USER_ID}" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"rol": "docente"}'
+```
+
+---
+
+## Limpieza
+
+Después de las pruebas, eliminar el usuario QA:
+
+```bash
+# Eliminar usuario QA (requiere service_role — esto es correcto para limpieza admin)
+curl -s -X DELETE \
+  "${SUPABASE_URL}/auth/v1/admin/users/${QA_USER_ID}" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
+```
+
+O desde SQL local:
+
+```sql
+-- Limpiar usuario QA de prueba
+DELETE FROM auth.users WHERE email = 'qa-test-docente@sase-test.local';
+```
+
+---
+
+## Caso especial: Modificación por servicio administrativo (DEBE permitirse)
+
+Los flujos server-side y Edge Functions que usan `service_role` key **sí** pueden modificar campos sensibles. Esto es correcto y esperado:
+
+- **Actor:** Edge Functions, API handlers server-side.
+- **Mecanismo:** `createClient(url, SERVICE_ROLE_KEY)` que evade RLS.
+- **Uso legítimo:** Crear/aprobar personal, cambiar roles por decisión institucional, bloquear usuarios.
+- **Resultado esperado:** Éxito total sin restricciones RLS.
+
+> [!NOTE]
+> La clave `service_role` es un secreto de servidor. Nunca debe exponerse al cliente ni usarse en código frontend.
+
+---
+
+## Resumen de validación
+
+| # | Prueba | Método recomendado | Resultado esperado |
+|---|--------|-------------------|-------------------|
+| 1 | Self-update de `rol` | A o B | ❌ Bloqueado |
+| 2 | Self-update de `permisos` | A o B | ❌ Bloqueado |
+| 3 | Self-update de `alcances` | A o B | ❌ Bloqueado |
+| 4 | Self-update de `matricula_sase` | A o B | ❌ Bloqueado |
+| 5 | Self-update de `email` | A o B | ❌ Bloqueado |
+| 6 | Self-update de `role` (legacy) | A o B | ❌ Bloqueado |
+| 7 | Self-update de `seguridad_status` | A o B | ❌ Bloqueado |
+| 8 | Self-update de `blocked_until` | A o B | ❌ Bloqueado |
+| 9 | Self-update de `grupo_tutor` | A o B | ❌ Bloqueado |
+| 10 | Self-update de `grupos` | A o B | ❌ Bloqueado |
+| 11 | Self-update de `nombre_completo` | A o B | ✅ Permitido |
+| 12 | Self-update de `telefono` | A o B | ✅ Permitido |
+| 13 | Self-update de `preferencias_dashboard` | A o B | ✅ Permitido |
+| 14 | Lectura de perfil propio | A o B | ✅ Permitido |
+| 15 | Modificación admin vía service_role | N/A (server) | ✅ Permitido |

--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -127,12 +127,12 @@ async function main() {
     { name: "matricula_sase", table: "perfiles_usuario", payload: { matricula_sase: "HACK-001" }, expectBlocked: true },
     { name: "email", table: "perfiles_usuario", payload: { email: "hacked@evil.com" }, expectBlocked: true },
     { name: "role (legacy)", table: "perfiles_usuario", payload: { role: "directivo" }, expectBlocked: true },
-    { name: "seguridad_status", table: "perfiles_usuario", payload: { seguridad_status: "active" }, expectBlocked: true },
+    { name: "seguridad_status", table: "perfiles_usuario", payload: { seguridad_status: "restricted" }, expectBlocked: true },
     { name: "blocked_until → 2099", table: "perfiles_usuario", payload: { blocked_until: "2099-01-01T00:00:00.000Z" }, expectBlocked: true }, // Se usa un valor futuro distinto al actual para probar que realmente está congelado (NULL a NULL no lo probaría)
     { name: "grupo_tutor", table: "perfiles_usuario", payload: { grupo_tutor: "admin-group" }, expectBlocked: true },
     { name: "grupos", table: "perfiles_usuario", payload: { grupos: ["all-access"] }, expectBlocked: true },
-    { name: "estado_cuenta", table: "perfiles_usuario", payload: { estado_cuenta: "active" }, expectBlocked: true },
-    { name: "risk_score", table: "perfiles_usuario", payload: { risk_score: 0 }, expectBlocked: true },
+    { name: "estado_cuenta", table: "perfiles_usuario", payload: { estado_cuenta: "suspendido" }, expectBlocked: true },
+    { name: "risk_score", table: "perfiles_usuario", payload: { risk_score: 100 }, expectBlocked: true },
   ];
 
   // Campo que DEBE ser bloqueado en profiles (tabla legacy)
@@ -174,7 +174,10 @@ async function main() {
   process.exit(allPass ? 0 : 1);
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
 ```
 
 ### Ejecución
@@ -236,14 +239,14 @@ curl -s -X PATCH \
 
 # Resultado esperado: [] o error 40x
 
-# Intentar cambiar seguridad_status (usando un valor válido de constraint 'active' para que el error provenga del RLS y no de una constraint de dominio)
+# Intentar cambiar seguridad_status
 curl -s -X PATCH \
   "${SUPABASE_URL}/rest/v1/perfiles_usuario?id=eq.${USER_ID}" \
   -H "apikey: ${SUPABASE_ANON_KEY}" \
   -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   -H "Content-Type: application/json" \
   -H "Prefer: return=representation" \
-  -d '{"seguridad_status": "active"}'
+  -d '{"seguridad_status": "restricted"}'
 
 # Resultado esperado: [] o error 40x
 ```
@@ -321,28 +324,36 @@ BEGIN;
   SELECT set_config('request.jwt.claim.role', 'authenticated', true);
 
   -- ── Prueba 1: Intentar autoescalamiento de rol (DEBE FALLAR) ──
+  SAVEPOINT before_test1;
   UPDATE public.perfiles_usuario
   SET rol = 'admin'
   WHERE id = '<uuid-real-del-usuario-qa>';
   -- Esperado: 0 filas afectadas (la política WITH CHECK lo rechaza)
+  ROLLBACK TO before_test1;
 
   -- ── Prueba 2: Intentar modificar permisos (DEBE FALLAR) ──
+  SAVEPOINT before_test2;
   UPDATE public.perfiles_usuario
   SET permisos = '{"all": true}'::jsonb
   WHERE id = '<uuid-real-del-usuario-qa>';
   -- Esperado: 0 filas afectadas
+  ROLLBACK TO before_test2;
 
   -- ── Prueba 3: Intentar modificar seguridad_status (DEBE FALLAR) ──
+  SAVEPOINT before_test3;
   UPDATE public.perfiles_usuario
-  SET seguridad_status = 'active'
+  SET seguridad_status = 'restricted'
   WHERE id = '<uuid-real-del-usuario-qa>';
   -- Esperado: 0 filas afectadas
+  ROLLBACK TO before_test3;
 
   -- ── Prueba 4: Modificar nombre_completo (DEBE TENER ÉXITO) ──
+  SAVEPOINT before_test4;
   UPDATE public.perfiles_usuario
   SET nombre_completo = 'QA Test User SQL'
   WHERE id = '<uuid-real-del-usuario-qa>';
   -- Esperado: 1 fila afectada ✅
+  RELEASE SAVEPOINT before_test4;
 
   -- Verificar estado final
   SELECT id, rol, nombre_completo, seguridad_status
@@ -393,6 +404,14 @@ curl -s -X PATCH \
   -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"rol": "docente"}'
+
+# Crear fila legacy profile si existe la tabla (usar service_role para SETUP)
+curl -s -X POST \
+  "${SUPABASE_URL}/rest/v1/profiles" \
+  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"${QA_USER_ID}\", \"role\": \"docente\"}"
 ```
 
 ---

--- a/docs/security/role-self-escalation-test.md
+++ b/docs/security/role-self-escalation-test.md
@@ -1,0 +1,155 @@
+# Prueba Manual: Prevención de Autoescalamiento de Roles
+
+**Migración:** `20260606150001_prevent_role_self_escalation.sql`
+**Fecha:** 2026-06-06
+**Tester:**
+
+---
+
+## Prerrequisitos
+
+1. Tener dos cuentas:
+   - **Usuario A**: rol `docente` / `docente_tutor`
+   - **Usuario B**: rol `directivo` / `system_admin` (cuenta de administración)
+2. Conocer el `id` de ambas cuentas (UUID de `auth.users`).
+3. Tener acceso a `supabase` SQL Editor (o psql) con `service_role` para verificar datos.
+4. Tener acceso autenticado desde la aplicación (frontend) para las pruebas de interfaz.
+
+---
+
+## Caso 1: Usuario normal intenta actualizar su propio rol
+
+### Desde SQL Editor (simula cliente autenticado)
+
+```sql
+-- Autenticarse como Usuario A (docente)
+-- Esto debe FALLAR con error "new row violates row-level security policy"
+UPDATE public.perfiles_usuario
+SET rol = 'system_admin'
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** `ERROR: new row violates row-level security policy`
+
+### Desde la aplicación frontend
+
+1. Inicia sesión como Usuario A.
+2. Abre la consola del navegador (F12 → Network).
+3. Ejecuta desde la consola:
+   ```js
+   const { data, error } = await supabase
+     .from('perfiles_usuario')
+     .update({ rol: 'system_admin' })
+     .eq('id', supabase.auth.user().id);
+   console.log('Error:', error);
+   ```
+4. **Resultado esperado:** `error` no es nulo, `data` es nulo.
+
+---
+
+## Caso 2: Usuario normal intenta actualizar sus permisos
+
+```sql
+UPDATE public.perfiles_usuario
+SET permisos = '{"can_approve_staff": true}'
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** `ERROR: new row violates row-level security policy`
+
+---
+
+## Caso 3: Usuario normal intenta actualizar sus alcances
+
+```sql
+UPDATE public.perfiles_usuario
+SET alcances = '{"can_view_audit": true}'
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** `ERROR: new row violates row-level security policy`
+
+---
+
+## Caso 4: AuthProvider sigue pudiendo leer el rol
+
+```sql
+-- Simula SELECT que hace AuthProvider
+SELECT id, rol, permisos, alcances
+FROM public.perfiles_usuario
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** Debe devolver la fila completa sin error.
+
+Desde la app: Inicia sesión como Usuario A y verifica que la app carga correctamente y muestra el dashboard correspondiente a `docente`.
+
+---
+
+## Caso 5: Usuario administrativo autorizado gestiona roles (flujo permitido)
+
+Los roles sensibles deben actualizarse SOLO mediante Edge Functions que usan `service_role` (bypassean RLS):
+
+```sql
+-- Esto solo funciona con service_role, no desde cliente
+UPDATE public.perfiles_usuario
+SET rol = 'directivo'
+WHERE id = '<uuid-usuario-b>';
+```
+
+**Resultado esperado:** Con `service_role`: exitoso. Desde cliente: error RLS.
+
+---
+
+## Caso 6: Usuario normal actualiza campos permitidos
+
+```sql
+-- Esto DEBE funcionar (campos no protegidos)
+UPDATE public.perfiles_usuario
+SET nombre_completo = 'Nuevo Nombre',
+    telefono = '5512345678',
+    preferencias_dashboard = '{"avatar_url": "https://..."}'
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** Éxito. Verificar con SELECT que los cambios persisten.
+
+---
+
+## Caso 7: Profiles — usuario normal no puede cambiar su role
+
+```sql
+UPDATE public.profiles
+SET role = 'directivo'
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** `ERROR: new row violates row-level security policy`
+
+```sql
+-- Sí debe poder actualizar full_name
+UPDATE public.profiles
+SET full_name = 'Nombre Visible'
+WHERE id = '<uuid-usuario-a>';
+```
+
+**Resultado esperado:** Éxito.
+
+---
+
+## Verificación post-prueba
+
+```sql
+-- Restaurar datos originales si es necesario
+-- (solo con service_role)
+```
+
+## Checklist
+
+- [ ] Caso 1: rol propio bloqueado
+- [ ] Caso 2: permisos propios bloqueados
+- [ ] Caso 3: alcances propios bloqueados
+- [ ] Caso 4: SELECT de AuthProvider funciona
+- [ ] Caso 5: service_role aún puede gestionar roles
+- [ ] Caso 6: campos permitidos (nombre, teléfono) sí se actualizan
+- [ ] Caso 7: profiles.role bloqueado

--- a/specs/002-seguridad-y-supabase-hardening/spec.md
+++ b/specs/002-seguridad-y-supabase-hardening/spec.md
@@ -92,3 +92,50 @@ entonces no debe fallar por un `ALLOWED_ORIGINS` desalineado con el puerto real.
 - `whatsapp.ts` aplica autorización por rol y auditoría válida.
 - El entorno local mínimo queda alineado con el comportamiento real del repo.
 - Existe validación reproducible para confirmar que no se rompió registro ni aprobación.
+
+## Hardening RLS y Autoescalamiento (PR #91)
+
+### Problema Original
+Se detectó una vulnerabilidad de autoescalamiento de roles y permisos mediante *self-update* en las tablas `public.perfiles_usuario` y `public.profiles`.
+
+### Tablas Afectadas
+- `public.perfiles_usuario`
+- `public.profiles`
+
+### Campos Congelados para Self-Update
+- `rol`
+- `role`
+- `permisos`
+- `alcances`
+- `matricula_sase`
+- `email`
+- `seguridad_status`
+- `blocked_until`
+- `grupo_tutor`
+- `grupos`
+- `estado_cuenta`
+- `risk_score`
+
+### Decisión Técnica
+- Helpers movidos a schema `private`.
+- `REVOKE ALL FROM PUBLIC, anon`.
+- `GRANT EXECUTE TO postgres, authenticated`.
+- Evitar superficie RPC pública.
+- Evitar recursión infinita RLS.
+
+### Validación
+- `pnpm type-check`: PASS
+- `pnpm test`: PASS, 100 pruebas
+- `pnpm build`: PASS
+- `pnpm lint`: PASS con warnings no bloqueantes
+- `npx supabase db reset`: pendiente por Docker no disponible
+- `audit-migrations.sh`: pendiente por CRLF/LF del entorno
+
+### Riesgo Residual
+- Falta prueba real en staging/Supabase con usuario QA autenticado.
+
+### Criterios de Aceptación antes de merge
+- Validar en staging que usuario QA no puede modificar campos congelados.
+- Confirmar que sí puede modificar campos permitidos.
+- Verificar que no haya error de recursión RLS.
+- Pedir rereview en GitHub.

--- a/specs/002-seguridad-y-supabase-hardening/spec.md
+++ b/specs/002-seguridad-y-supabase-hardening/spec.md
@@ -54,6 +54,7 @@ Hoy existen fallas verificadas de seguridad y consistencia que vuelven frágil l
 - FR-008: `.env.example` debe reflejar el puerto local real y las variables server-side mínimas que el repositorio ya usa.
 - FR-009: `supabase/config.toml` debe apuntar al seed real del repositorio o dejar explícita la ausencia de seed compatible.
 - FR-010: Todo cambio de esta fase debe quedar respaldado por migración trazable y guía de validación en `quickstart.md`.
+- FR-011: Los campos sensibles de identidad, rol, permisos, alcances, seguridad y grupo en `perfiles_usuario` deben ser inmutables para self-update por el usuario autenticado. Solo flujos server-side o service_role pueden modificarlos.
 
 ## Escenarios de aceptación
 

--- a/specs/002-seguridad-y-supabase-hardening/tasks.md
+++ b/specs/002-seguridad-y-supabase-hardening/tasks.md
@@ -74,7 +74,7 @@
 ## Fase 10 — Prevención de autoescalamiento de roles (PR #91, 2026-06-08)
 
 - [ ] T035 Migración `prevent_role_self_escalation`: Campos sensibles (rol, permisos, alcances, matricula_sase, email, role) protegidos contra self-update via RLS WITH CHECK.
-- [ ] T036 Migración `fix_rls_helpers_hardening`: Helpers SECURITY DEFINER movidos a schema `private`, ejecución revocada para public/anon/authenticated. Campos seguridad_status, blocked_until, grupo_tutor, grupos agregados al conjunto inmutable.
+- [ ] T036 Migración `fix_rls_helpers_hardening`: Helpers SECURITY DEFINER movidos a schema `private`, el cual no se expone como API pública por PostgREST. `authenticated` necesita `USAGE` sobre el schema `private` y `EXECUTE` sobre los helpers usados en policies; esto no abre RPC pública. `anon` no debe tener permisos. Campos `seguridad_status`, `blocked_until`, `grupo_tutor`, `grupos` agregados al conjunto inmutable.
 - [ ] T037 Corrección Sasito: Matching de señales rojas por word-boundary (evita falsos positivos de subcadena). Prioridad de señales rojas sobre coincidencias académicas.
 - [ ] T038 Runbook de pruebas RLS: Corregido para usar cliente autenticado real en vez de SQL Editor con service_role.
 - [ ] T039 Verificación: pnpm type-check, pnpm test, pnpm build, audit-migrations.sh

--- a/specs/002-seguridad-y-supabase-hardening/tasks.md
+++ b/specs/002-seguridad-y-supabase-hardening/tasks.md
@@ -70,3 +70,32 @@
 - [x] T032 Agregar slice/store frontend para consultar el snapshot sin leer catálogos directamente desde React.
 - [x] T033 Implementar `SecurityDashboard` y exponerlo en navegación para Dirección, Soporte Nivel 3 y Desarrollo.
 - [x] T034 Verificar `npm run lint`, `npm run type-check`, `npm run test`, `npm run build` y `./scripts/audit-migrations.sh` tras la integración.
+
+## Fase 10 — Prevención de autoescalamiento de roles (PR #91, 2026-06-08)
+
+- [ ] T035 Migración `prevent_role_self_escalation`: Campos sensibles (rol, permisos, alcances, matricula_sase, email, role) protegidos contra self-update via RLS WITH CHECK.
+- [ ] T036 Migración `fix_rls_helpers_hardening`: Helpers SECURITY DEFINER movidos a schema `private`, ejecución revocada para public/anon/authenticated. Campos seguridad_status, blocked_until, grupo_tutor, grupos agregados al conjunto inmutable.
+- [ ] T037 Corrección Sasito: Matching de señales rojas por word-boundary (evita falsos positivos de subcadena). Prioridad de señales rojas sobre coincidencias académicas.
+- [ ] T038 Runbook de pruebas RLS: Corregido para usar cliente autenticado real en vez de SQL Editor con service_role.
+- [ ] T039 Verificación: pnpm type-check, pnpm test, pnpm build, audit-migrations.sh
+
+### Campos protegidos contra self-update
+
+| Tabla | Campo | Razón |
+|-------|-------|-------|
+| perfiles_usuario | rol | Escalamiento de privilegios |
+| perfiles_usuario | permisos | Modificación de permisos JSONB |
+| perfiles_usuario | alcances | Modificación de alcances JSONB |
+| perfiles_usuario | matricula_sase | Identidad institucional |
+| perfiles_usuario | email | Identidad |
+| perfiles_usuario | role | Campo legacy de rol |
+| perfiles_usuario | seguridad_status | Bloqueo de seguridad |
+| perfiles_usuario | blocked_until | Bloqueo temporal |
+| perfiles_usuario | grupo_tutor | Scope de grupo para tokens |
+| perfiles_usuario | grupos | Scope de grupos para tokens |
+| profiles | role | Rol en tabla legacy |
+
+### Riesgos residuales
+
+- Validación completa pendiente en Supabase real/staging con usuario QA.
+- El campo `risk_score` en perfiles_usuario no está protegido explícitamente (usado solo en lectura por Login.tsx).

--- a/src/data/sasitoExperienceCatalog.ts
+++ b/src/data/sasitoExperienceCatalog.ts
@@ -1,0 +1,177 @@
+import type { SasitoExperience } from "../types/sasitoExperience";
+
+export const SASITO_EXPERIENCE_CATALOG: readonly SasitoExperience[] = [
+  {
+    id: "salida_aula_sin_autorizacion",
+    nombre: "Salida del aula sin autorizacion",
+    tipo: "seguridad",
+    senales: ["sale del aula", "abandona clase", "salida sin autorizacion", "fuera del aula"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar la salida no autorizada con hora y contexto",
+      "verificar retorno seguro del alumno",
+      "notificar a prefectura si existe reincidencia",
+    ],
+    noHacer: [
+      "perseguir al alumno sin apoyo institucional",
+      "cerrar el caso sin confirmar ubicacion",
+    ],
+    plantillaSugerida: "registro_salida_aula",
+    activo: true,
+  },
+  {
+    id: "no_trabaja_en_clase",
+    nombre: "No trabaja en clase",
+    tipo: "academica",
+    senales: ["no trabaja", "no realiza actividad", "no entrega evidencia", "sin trabajo en clase"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar observacion academica en clase",
+      "ofrecer instruccion breve y verificable",
+      "dar seguimiento si se repite en tres ocasiones",
+    ],
+    noHacer: [
+      "etiquetar al alumno como desinteresado",
+      "escalar sin evidencia de reincidencia",
+    ],
+    plantillaSugerida: "observacion_academica",
+    activo: true,
+  },
+  {
+    id: "lenguaje_ofensivo",
+    nombre: "Lenguaje ofensivo",
+    tipo: "conductual",
+    senales: ["insulta", "lenguaje ofensivo", "ofensa verbal", "groserias"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar palabras o conducta observada sin juicios",
+      "redireccionar con indicacion breve",
+      "solicitar apoyo si hay escalamiento verbal",
+    ],
+    noHacer: [
+      "responder con confrontacion",
+      "registrar interpretaciones sin hechos observables",
+    ],
+    plantillaSugerida: "registro_conductual",
+    activo: true,
+  },
+  {
+    id: "desacato_indicaciones",
+    nombre: "Desacato de indicaciones",
+    tipo: "conductual",
+    senales: ["no sigue indicaciones", "desacato", "ignora instrucciones", "rechaza indicacion"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar la indicacion dada y la respuesta observada",
+      "repetir la instruccion de forma breve",
+      "documentar reincidencias antes de escalar",
+    ],
+    noHacer: [
+      "elevar el tono de la confrontacion",
+      "convertir una negativa aislada en falta grave sin contexto",
+    ],
+    plantillaSugerida: "registro_conductual",
+    activo: true,
+  },
+  {
+    id: "agresion_fisica",
+    nombre: "Agresion fisica",
+    tipo: "seguridad",
+    senales: ["agresion fisica", "golpe", "empujon", "pelea", "lesion fisica"],
+    riesgoBase: "rojo",
+    accionesRecomendadas: [
+      "activar protocolo institucional de seguridad",
+      "separar a los alumnos con apoyo adulto",
+      "notificar a direccion y registrar hechos observables",
+    ],
+    noHacer: [
+      "mediar sin condiciones de seguridad",
+      "minimizar lesiones o amenazas",
+    ],
+    plantillaSugerida: "protocolo_seguridad",
+    activo: true,
+  },
+  {
+    id: "posible_riesgo_seguridad",
+    nombre: "Posible riesgo de seguridad",
+    tipo: "seguridad",
+    senales: [
+      "posible arma",
+      "arma",
+      "fuego",
+      "incendio",
+      "alumno no localizado",
+      "no localizado",
+      "conducta sexualizada",
+      "riesgo de seguridad",
+    ],
+    riesgoBase: "rojo",
+    accionesRecomendadas: [
+      "activar protocolo institucional de seguridad",
+      "avisar a direccion o prefectura de inmediato",
+      "registrar solo hechos confirmados y personas notificadas",
+    ],
+    noHacer: [
+      "confrontar al alumno sin apoyo",
+      "difundir informacion no confirmada",
+    ],
+    plantillaSugerida: "protocolo_seguridad",
+    activo: true,
+  },
+  {
+    id: "citatorio_sin_respuesta",
+    nombre: "Citatorio sin respuesta",
+    tipo: "familiar",
+    senales: ["citatorio sin respuesta", "familia no responde", "sin respuesta familiar", "no acude tutor"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar fecha y medio del citatorio",
+      "intentar segundo contacto institucional",
+      "escalar a trabajo social si se repite",
+    ],
+    noHacer: [
+      "asumir negligencia sin evidencia",
+      "cerrar seguimiento sin segundo intento documentado",
+    ],
+    plantillaSugerida: "seguimiento_familiar",
+    activo: true,
+  },
+  {
+    id: "uso_indebido_celular",
+    nombre: "Uso indebido de celular",
+    tipo: "conductual",
+    senales: ["uso de celular", "celular en clase", "graba sin permiso", "telefono en clase"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar uso observado y momento de clase",
+      "aplicar indicacion institucional sobre dispositivo",
+      "dar seguimiento si hay reincidencia",
+    ],
+    noHacer: [
+      "retener pertenencias sin procedimiento institucional",
+      "revisar contenido personal del dispositivo",
+    ],
+    plantillaSugerida: "registro_conductual",
+    activo: true,
+  },
+  {
+    id: "conducta_positiva",
+    nombre: "Conducta positiva",
+    tipo: "seguimiento",
+    senales: ["conducta positiva", "apoyo a companero", "participacion positiva", "mejora observable"],
+    riesgoBase: "verde",
+    accionesRecomendadas: [
+      "registrar reconocimiento positivo",
+      "vincular evidencia con seguimiento institucional",
+    ],
+    noHacer: [
+      "usar el registro positivo para compensar faltas no atendidas",
+      "exponer publicamente informacion sensible del alumno",
+    ],
+    plantillaSugerida: "reconocimiento_positivo",
+    activo: true,
+  },
+];
+
+export const findSasitoExperienceById = (id: string): SasitoExperience | undefined =>
+  SASITO_EXPERIENCE_CATALOG.find((experience) => experience.activo && experience.id === id);

--- a/src/lib/sasito/classifyIncident.ts
+++ b/src/lib/sasito/classifyIncident.ts
@@ -60,11 +60,12 @@ export const classifyIncident = (input: SasitoIncidentInput): SasitoRecommendati
 
   const risk = resolveSasitoRisk(input, experience);
 
-  // P2 fix: When red safety signal is detected but experience is not security-type,
-  // override with security experience to ensure proper protocol.
-  if (risk.riesgo === "rojo" && experience.tipo !== "seguridad") {
+  // P2 fix: When red safety signal is detected, override with the specific
+  // security experience to ensure proper protocol, even if the base experience
+  // is already of type "seguridad".
+  if (risk.riesgo === "rojo") {
     const securityExperience = findSecurityExperienceByRule(risk.reglaAplicada);
-    if (securityExperience) {
+    if (securityExperience && experience.id !== securityExperience.id) {
       return {
         experienciaId: securityExperience.id,
         experienciaNombre: securityExperience.nombre,

--- a/src/lib/sasito/classifyIncident.ts
+++ b/src/lib/sasito/classifyIncident.ts
@@ -3,7 +3,20 @@ import {
   SASITO_EXPERIENCE_CATALOG,
 } from "../../data/sasitoExperienceCatalog";
 import type { SasitoExperience, SasitoIncidentInput, SasitoRecommendation } from "../../types/sasitoExperience";
-import { HUMAN_REVIEW_ACTION, normalizeSasitoText, resolveSasitoRisk } from "./riskRules";
+import { HUMAN_REVIEW_ACTION, matchesAnyTerm, normalizeSasitoText, resolveSasitoRisk } from "./riskRules";
+
+const RULE_TO_EXPERIENCE_MAP: Record<string, string> = {
+  agresion_fisica: "agresion_fisica",
+  posible_arma: "posible_riesgo_seguridad",
+  fuego: "posible_riesgo_seguridad",
+  alumno_no_localizado: "posible_riesgo_seguridad",
+  conducta_sexualizada: "posible_riesgo_seguridad",
+};
+
+const findSecurityExperienceByRule = (rule: string): SasitoExperience | undefined => {
+  const experienceId = RULE_TO_EXPERIENCE_MAP[rule];
+  return experienceId ? findSasitoExperienceById(experienceId) : undefined;
+};
 
 const findExperienceBySignals = (input: SasitoIncidentInput): SasitoExperience | undefined => {
   const normalizedInput = normalizeSasitoText(
@@ -21,7 +34,7 @@ const findExperienceBySignals = (input: SasitoIncidentInput): SasitoExperience |
     return (
       normalizedInput.includes(normalizedId) ||
       normalizedInput.includes(normalizedName) ||
-      experience.senales.some((signal) => normalizedInput.includes(normalizeSasitoText(signal)))
+      matchesAnyTerm(normalizedInput, experience.senales.map((s) => normalizeSasitoText(s)))
     );
   });
 };
@@ -46,6 +59,26 @@ export const classifyIncident = (input: SasitoIncidentInput): SasitoRecommendati
   }
 
   const risk = resolveSasitoRisk(input, experience);
+
+  // P2 fix: When red safety signal is detected but experience is not security-type,
+  // override with security experience to ensure proper protocol.
+  if (risk.riesgo === "rojo" && experience.tipo !== "seguridad") {
+    const securityExperience = findSecurityExperienceByRule(risk.reglaAplicada);
+    if (securityExperience) {
+      return {
+        experienciaId: securityExperience.id,
+        experienciaNombre: securityExperience.nombre,
+        tipo: securityExperience.tipo,
+        riesgo: "rojo",
+        accionesRecomendadas: [...securityExperience.accionesRecomendadas],
+        noHacer: [...securityExperience.noHacer],
+        plantillaSugerida: securityExperience.plantillaSugerida,
+        requiereEscalamiento: true,
+        reglaAplicada: risk.reglaAplicada,
+        revisionHumana: false,
+      };
+    }
+  }
 
   return {
     experienciaId: experience.id,

--- a/src/lib/sasito/classifyIncident.ts
+++ b/src/lib/sasito/classifyIncident.ts
@@ -3,7 +3,7 @@ import {
   SASITO_EXPERIENCE_CATALOG,
 } from "../../data/sasitoExperienceCatalog";
 import type { SasitoExperience, SasitoIncidentInput, SasitoRecommendation } from "../../types/sasitoExperience";
-import { HUMAN_REVIEW_ACTION, matchesAnyTerm, normalizeSasitoText, resolveSasitoRisk } from "./riskRules";
+import { HUMAN_REVIEW_ACTION, matchesAnyTerm, normalizeSasitoText, resolveSasitoRisk, detectRedSignal } from "./riskRules";
 
 const RULE_TO_EXPERIENCE_MAP: Record<string, string> = {
   agresion_fisica: "agresion_fisica",
@@ -55,6 +55,24 @@ export const classifyIncident = (input: SasitoIncidentInput): SasitoRecommendati
     : findExperienceBySignals(input);
 
   if (!experience) {
+    const redSignal = detectRedSignal(input);
+    if (redSignal) {
+      const securityExperience = findSecurityExperienceByRule(redSignal);
+      if (securityExperience) {
+        return {
+          experienciaId: securityExperience.id,
+          experienciaNombre: securityExperience.nombre,
+          tipo: securityExperience.tipo,
+          riesgo: "rojo",
+          accionesRecomendadas: [...securityExperience.accionesRecomendadas],
+          noHacer: [...securityExperience.noHacer],
+          plantillaSugerida: securityExperience.plantillaSugerida,
+          requiereEscalamiento: true,
+          reglaAplicada: redSignal,
+          revisionHumana: false,
+        };
+      }
+    }
     return buildUnknownRecommendation();
   }
 

--- a/src/lib/sasito/classifyIncident.ts
+++ b/src/lib/sasito/classifyIncident.ts
@@ -1,0 +1,62 @@
+import {
+  findSasitoExperienceById,
+  SASITO_EXPERIENCE_CATALOG,
+} from "../../data/sasitoExperienceCatalog";
+import type { SasitoExperience, SasitoIncidentInput, SasitoRecommendation } from "../../types/sasitoExperience";
+import { HUMAN_REVIEW_ACTION, normalizeSasitoText, resolveSasitoRisk } from "./riskRules";
+
+const findExperienceBySignals = (input: SasitoIncidentInput): SasitoExperience | undefined => {
+  const normalizedInput = normalizeSasitoText(
+    [input.experienciaId, input.conducta, input.descripcion].filter(Boolean).join(" "),
+  );
+
+  return SASITO_EXPERIENCE_CATALOG.find((experience) => {
+    if (!experience.activo) {
+      return false;
+    }
+
+    const normalizedId = normalizeSasitoText(experience.id);
+    const normalizedName = normalizeSasitoText(experience.nombre);
+
+    return (
+      normalizedInput.includes(normalizedId) ||
+      normalizedInput.includes(normalizedName) ||
+      experience.senales.some((signal) => normalizedInput.includes(normalizeSasitoText(signal)))
+    );
+  });
+};
+
+const buildUnknownRecommendation = (): SasitoRecommendation => ({
+  tipo: "seguimiento",
+  riesgo: "verde",
+  accionesRecomendadas: [HUMAN_REVIEW_ACTION],
+  noHacer: ["inventar acciones o diagnosticos sin revision humana"],
+  requiereEscalamiento: false,
+  reglaAplicada: "conducta_no_reconocida",
+  revisionHumana: true,
+});
+
+export const classifyIncident = (input: SasitoIncidentInput): SasitoRecommendation => {
+  const experience = input.experienciaId
+    ? findSasitoExperienceById(input.experienciaId) ?? findExperienceBySignals(input)
+    : findExperienceBySignals(input);
+
+  if (!experience) {
+    return buildUnknownRecommendation();
+  }
+
+  const risk = resolveSasitoRisk(input, experience);
+
+  return {
+    experienciaId: experience.id,
+    experienciaNombre: experience.nombre,
+    tipo: experience.tipo,
+    riesgo: risk.riesgo,
+    accionesRecomendadas: [...experience.accionesRecomendadas],
+    noHacer: [...experience.noHacer],
+    plantillaSugerida: experience.plantillaSugerida,
+    requiereEscalamiento: risk.riesgo === "rojo",
+    reglaAplicada: risk.reglaAplicada,
+    revisionHumana: false,
+  };
+};

--- a/src/lib/sasito/riskRules.ts
+++ b/src/lib/sasito/riskRules.ts
@@ -33,7 +33,8 @@ const hasThreeReincidences = (input: SasitoIncidentInput): boolean =>
 export const matchesAnyTerm = (normalizedText: string, terms: readonly string[]): boolean =>
   terms.some((term) => {
     const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(?:^|\\s)${escaped}(?:\\s|$)`).test(normalizedText);
+    // Usamos \b para que cualquier no-alfanumérico (incluida puntuación) cuente como límite
+    return new RegExp(`\\b${escaped}\\b`).test(normalizedText);
   });
 
 export const resolveSasitoRisk = (

--- a/src/lib/sasito/riskRules.ts
+++ b/src/lib/sasito/riskRules.ts
@@ -8,8 +8,8 @@ export interface SasitoRiskResolution {
 }
 
 const RED_SECURITY_RULES = [
-  { rule: "agresion_fisica", terms: ["agresion fisica", "golpe", "empujon", "pelea", "lesion fisica"] },
-  { rule: "posible_arma", terms: ["posible arma", "arma"] },
+  { rule: "agresion_fisica", terms: ["agresion fisica", "golpe", "golpes", "empujon", "empujones", "pelea", "lesion fisica"] },
+  { rule: "posible_arma", terms: ["posible arma", "arma", "armas"] },
   { rule: "fuego", terms: ["fuego", "incendio"] },
   { rule: "alumno_no_localizado", terms: ["alumno no localizado", "no localizado"] },
   { rule: "conducta_sexualizada", terms: ["conducta sexualizada"] },

--- a/src/lib/sasito/riskRules.ts
+++ b/src/lib/sasito/riskRules.ts
@@ -30,8 +30,11 @@ const hasReincidence = (input: SasitoIncidentInput): boolean =>
 const hasThreeReincidences = (input: SasitoIncidentInput): boolean =>
   (input.reincidenciasPrevias ?? 0) >= 3;
 
-const matchesAnyTerm = (normalizedText: string, terms: readonly string[]): boolean =>
-  terms.some((term) => normalizedText.includes(term));
+export const matchesAnyTerm = (normalizedText: string, terms: readonly string[]): boolean =>
+  terms.some((term) => {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(?:^|\\s)${escaped}(?:\\s|$)`).test(normalizedText);
+  });
 
 export const resolveSasitoRisk = (
   input: SasitoIncidentInput,

--- a/src/lib/sasito/riskRules.ts
+++ b/src/lib/sasito/riskRules.ts
@@ -1,0 +1,77 @@
+import type { RiskLevel, SasitoExperience, SasitoIncidentInput } from "../../types/sasitoExperience";
+
+export const HUMAN_REVIEW_ACTION = "registrar observacion para revision humana";
+
+export interface SasitoRiskResolution {
+  riesgo: RiskLevel;
+  reglaAplicada: string;
+}
+
+const RED_SECURITY_RULES = [
+  { rule: "agresion_fisica", terms: ["agresion fisica", "golpe", "empujon", "pelea", "lesion fisica"] },
+  { rule: "posible_arma", terms: ["posible arma", "arma"] },
+  { rule: "fuego", terms: ["fuego", "incendio"] },
+  { rule: "alumno_no_localizado", terms: ["alumno no localizado", "no localizado"] },
+  { rule: "conducta_sexualizada", terms: ["conducta sexualizada"] },
+] as const;
+
+export const normalizeSasitoText = (value: string): string =>
+  value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const hasReincidence = (input: SasitoIncidentInput): boolean =>
+  Boolean(input.esReincidencia) || (input.reincidenciasPrevias ?? 0) > 0;
+
+const hasThreeReincidences = (input: SasitoIncidentInput): boolean =>
+  (input.reincidenciasPrevias ?? 0) >= 3;
+
+const matchesAnyTerm = (normalizedText: string, terms: readonly string[]): boolean =>
+  terms.some((term) => normalizedText.includes(term));
+
+export const resolveSasitoRisk = (
+  input: SasitoIncidentInput,
+  experience: SasitoExperience,
+): SasitoRiskResolution => {
+  const normalizedText = normalizeSasitoText(
+    [input.experienciaId, input.conducta, input.descripcion].filter(Boolean).join(" "),
+  );
+
+  const redRule = RED_SECURITY_RULES.find((rule) => {
+    if (normalizeSasitoText(experience.id) === normalizeSasitoText(rule.rule)) {
+      return true;
+    }
+
+    return matchesAnyTerm(normalizedText, rule.terms);
+  });
+
+  if (redRule) {
+    return { riesgo: "rojo", reglaAplicada: redRule.rule };
+  }
+
+  if (experience.id === "conducta_positiva") {
+    return { riesgo: "verde", reglaAplicada: "conducta_positiva" };
+  }
+
+  if (experience.id === "citatorio_sin_respuesta" && hasReincidence(input)) {
+    return { riesgo: "amarillo", reglaAplicada: "citatorio_sin_respuesta_repetido" };
+  }
+
+  if (experience.id === "salida_aula_sin_autorizacion" && hasReincidence(input)) {
+    return { riesgo: "amarillo", reglaAplicada: "salida_aula_reincidente" };
+  }
+
+  if ((experience.tipo === "academica" || experience.tipo === "conductual") && hasThreeReincidences(input)) {
+    return { riesgo: "amarillo", reglaAplicada: "tres_reincidencias_academicas_o_conductuales" };
+  }
+
+  if (experience.tipo === "academica" && !hasReincidence(input)) {
+    return { riesgo: "verde", reglaAplicada: "academica_sin_reincidencia" };
+  }
+
+  return { riesgo: experience.riesgoBase, reglaAplicada: "riesgo_base_catalogo" };
+};

--- a/src/lib/sasito/riskRules.ts
+++ b/src/lib/sasito/riskRules.ts
@@ -37,6 +37,14 @@ export const matchesAnyTerm = (normalizedText: string, terms: readonly string[])
     return new RegExp(`\\b${escaped}\\b`).test(normalizedText);
   });
 
+export const detectRedSignal = (input: SasitoIncidentInput): string | undefined => {
+  const normalizedText = normalizeSasitoText(
+    [input.experienciaId, input.conducta, input.descripcion].filter(Boolean).join(" "),
+  );
+
+  return RED_SECURITY_RULES.find((rule) => matchesAnyTerm(normalizedText, rule.terms))?.rule;
+};
+
 export const resolveSasitoRisk = (
   input: SasitoIncidentInput,
   experience: SasitoExperience,
@@ -45,16 +53,17 @@ export const resolveSasitoRisk = (
     [input.experienciaId, input.conducta, input.descripcion].filter(Boolean).join(" "),
   );
 
-  const redRule = RED_SECURITY_RULES.find((rule) => {
-    if (normalizeSasitoText(experience.id) === normalizeSasitoText(rule.rule)) {
-      return true;
-    }
+  const redSignal = detectRedSignal(input);
+  if (redSignal) {
+    return { riesgo: "rojo", reglaAplicada: redSignal };
+  }
 
-    return matchesAnyTerm(normalizedText, rule.terms);
-  });
+  const redRuleByExperience = RED_SECURITY_RULES.find(
+    (rule) => normalizeSasitoText(experience.id) === normalizeSasitoText(rule.rule)
+  );
 
-  if (redRule) {
-    return { riesgo: "rojo", reglaAplicada: redRule.rule };
+  if (redRuleByExperience) {
+    return { riesgo: "rojo", reglaAplicada: redRuleByExperience.rule };
   }
 
   if (experience.id === "conducta_positiva") {

--- a/src/types/sasitoExperience.ts
+++ b/src/types/sasitoExperience.ts
@@ -1,0 +1,53 @@
+export type IncidenceType =
+  | "academica"
+  | "conductual"
+  | "seguridad"
+  | "socioemocional"
+  | "familiar"
+  | "inclusion_bap"
+  | "seguimiento";
+
+export type RiskLevel = "verde" | "amarillo" | "rojo";
+
+export type MomentOfRisk =
+  | "inicio_clase"
+  | "despues_receso"
+  | "cambio_clase"
+  | "trabajo_equipo"
+  | "entrega_evidencia"
+  | "cierre_clase"
+  | "pasillo_o_patio";
+
+export interface SasitoExperience {
+  id: string;
+  nombre: string;
+  tipo: IncidenceType;
+  senales: readonly string[];
+  riesgoBase: RiskLevel;
+  accionesRecomendadas: readonly string[];
+  noHacer: readonly string[];
+  plantillaSugerida?: string;
+  activo: boolean;
+}
+
+export interface SasitoIncidentInput {
+  conducta: string;
+  descripcion?: string;
+  experienciaId?: string;
+  reincidenciasPrevias?: number;
+  esReincidencia?: boolean;
+  momento?: MomentOfRisk;
+}
+
+export interface SasitoRecommendation {
+  experienciaId?: string;
+  experienciaNombre?: string;
+  tipo: IncidenceType;
+  riesgo: RiskLevel;
+  accionesRecomendadas: string[];
+  noHacer: string[];
+  plantillaSugerida?: string;
+  requiereEscalamiento: boolean;
+  reglaAplicada: string;
+  revisionHumana: boolean;
+}

--- a/supabase/migrations/20260606000000_prevent_role_self_escalation.sql
+++ b/supabase/migrations/20260606000000_prevent_role_self_escalation.sql
@@ -1,0 +1,35 @@
+-- Migration: Prevent Role, Permission, and Scope Self-Escalation
+-- Date: 2026-06-06
+-- Objective: Ensure users cannot update their own roles, permissions, or scopes via client updates.
+
+-- 1. Hardening on public.perfiles_usuario
+DROP POLICY IF EXISTS "Usuarios actualizan su propio perfil" ON public.perfiles_usuario;
+
+CREATE POLICY "Usuarios actualizan su propio perfil" ON public.perfiles_usuario
+  FOR UPDATE
+  TO authenticated
+  USING ( (SELECT auth.uid()) = id )
+  WITH CHECK (
+    (SELECT auth.uid()) = id
+    AND (
+      rol IS NOT DISTINCT FROM (SELECT rol FROM public.perfiles_usuario WHERE id = (SELECT auth.uid()))
+      AND role IS NOT DISTINCT FROM (SELECT role FROM public.perfiles_usuario WHERE id = (SELECT auth.uid()))
+      AND email IS NOT DISTINCT FROM (SELECT email FROM public.perfiles_usuario WHERE id = (SELECT auth.uid()))
+      AND matricula_sase IS NOT DISTINCT FROM (SELECT matricula_sase FROM public.perfiles_usuario WHERE id = (SELECT auth.uid()))
+      AND permisos IS NOT DISTINCT FROM (SELECT permisos FROM public.perfiles_usuario WHERE id = (SELECT auth.uid()))
+      AND alcances IS NOT DISTINCT FROM (SELECT alcances FROM public.perfiles_usuario WHERE id = (SELECT auth.uid()))
+    )
+  );
+
+-- 2. Hardening on public.profiles
+DROP POLICY IF EXISTS "Users can update their own profile." ON public.profiles;
+DROP POLICY IF EXISTS "Users update own profile" ON public.profiles;
+
+CREATE POLICY "Users can update their own profile." ON public.profiles
+  FOR UPDATE
+  TO authenticated
+  USING ( (SELECT auth.uid()) = id )
+  WITH CHECK (
+    (SELECT auth.uid()) = id
+    AND role IS NOT DISTINCT FROM (SELECT role FROM public.profiles WHERE id = (SELECT auth.uid()))
+  );

--- a/supabase/migrations/20260606150001_prevent_role_self_escalation.sql
+++ b/supabase/migrations/20260606150001_prevent_role_self_escalation.sql
@@ -1,0 +1,66 @@
+-- SASE-310 P0: Prevenir autoescalamiento de roles
+--
+-- Objetivo:
+--   Impedir que un usuario autenticado modifique su propio rol,
+--   permisos o alcances desde el cliente. Solo los flujos autorizados
+--   (invite-staff, approve-staff, system_admin RPC) pueden mutar
+--   campos sensibles.
+--
+-- Tablas afectadas:
+--   public.perfiles_usuario  — corrige WITH CHECK (era tautológico)
+--   public.profiles          — agrega WITH CHECK (no existía)
+--
+-- No rompe:
+--   AuthProvider (solo SELECT)
+--   PerfilUsuario.tsx (solo actualiza nombre_completo, telefono, preferencias_dashboard)
+--   Edge Functions (invoke con service_role bypassa RLS)
+
+-- ─────────────────────────────────────────────────────────────
+-- 1. perfiles_usuario: Recrear policy de UPDATE con protección real
+-- ─────────────────────────────────────────────────────────────
+-- La policy anterior tenía WITH CHECK con autorreferencias a NEW
+-- (rol IS NOT DISTINCT FROM rol → siempre true). Esta nueva policy
+-- compara cada campo sensible contra su valor almacenado.
+
+drop policy if exists "Usuarios actualizan su propio perfil" on public.perfiles_usuario;
+
+create policy "Usuarios actualizan su propio perfil"
+on public.perfiles_usuario
+for update
+to authenticated
+using (auth.uid() = id)
+with check (
+  auth.uid() = id
+  and (rol, permisos, alcances, matricula_sase, email, role)
+      is not distinct from (
+        select p.rol, p.permisos, p.alcances, p.matricula_sase, p.email, p.role
+        from public.perfiles_usuario p
+        where p.id = auth.uid()
+      )
+);
+
+-- ─────────────────────────────────────────────────────────────
+-- 2. profiles: Recrear policy de UPDATE con protección de role
+-- ─────────────────────────────────────────────────────────────
+-- La policy anterior no tenía WITH CHECK, permitiendo cambiar role.
+
+drop policy if exists "Users can update their own profile." on public.profiles;
+drop policy if exists "Users update own profile" on public.profiles;
+
+create policy "Users can update their own profile."
+on public.profiles
+for update
+to authenticated
+using (auth.uid() = id)
+with check (
+  auth.uid() = id
+  and role is not distinct from (
+    select p.role from public.profiles p where p.id = auth.uid()
+  )
+);
+
+-- ─────────────────────────────────────────────────────────────
+-- 3. Verificación
+-- ─────────────────────────────────────────────────────────────
+-- Intentos bloqueados por RLS no generan filas. Si se requiere
+-- auditoría de intentos denegados, debe hacerse desde frontend.

--- a/supabase/migrations/20260606150001_prevent_role_self_escalation.sql
+++ b/supabase/migrations/20260606150001_prevent_role_self_escalation.sql
@@ -16,11 +16,62 @@
 --   Edge Functions (invoke con service_role bypassa RLS)
 
 -- ─────────────────────────────────────────────────────────────
+-- 0. Funciones Auxiliares SECURITY DEFINER para evitar recursión
+-- ─────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.check_perfil_usuario_unmodified(
+  p_id uuid,
+  p_new_rol text,
+  p_new_permisos jsonb,
+  p_new_alcances jsonb,
+  p_new_matricula text,
+  p_new_email text,
+  p_new_role text
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+declare
+  v_old public.perfiles_usuario;
+begin
+  select * into v_old from public.perfiles_usuario where id = p_id;
+  if not found then
+    return true;
+  end if;
+  return (
+    p_new_rol is not distinct from v_old.rol
+    and p_new_permisos is not distinct from v_old.permisos
+    and p_new_alcances is not distinct from v_old.alcances
+    and p_new_matricula is not distinct from v_old.matricula_sase
+    and p_new_email is not distinct from v_old.email
+    and p_new_role is not distinct from v_old.role
+  );
+end;
+$$;
+
+CREATE OR REPLACE FUNCTION public.check_profile_unmodified(
+  p_id uuid,
+  p_new_role public.app_role
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+declare
+  v_old_role public.app_role;
+begin
+  select role into v_old_role from public.profiles where id = p_id;
+  if not found then
+    return true;
+  end if;
+  return p_new_role is not distinct from v_old_role;
+end;
+$$;
+
+-- ─────────────────────────────────────────────────────────────
 -- 1. perfiles_usuario: Recrear policy de UPDATE con protección real
 -- ─────────────────────────────────────────────────────────────
--- La policy anterior tenía WITH CHECK con autorreferencias a NEW
--- (rol IS NOT DISTINCT FROM rol → siempre true). Esta nueva policy
--- compara cada campo sensible contra su valor almacenado.
 
 drop policy if exists "Usuarios actualizan su propio perfil" on public.perfiles_usuario;
 
@@ -31,18 +82,12 @@ to authenticated
 using (auth.uid() = id)
 with check (
   auth.uid() = id
-  and (rol, permisos, alcances, matricula_sase, email, role)
-      is not distinct from (
-        select p.rol, p.permisos, p.alcances, p.matricula_sase, p.email, p.role
-        from public.perfiles_usuario p
-        where p.id = auth.uid()
-      )
+  and public.check_perfil_usuario_unmodified(id, rol, permisos, alcances, matricula_sase, email, role)
 );
 
 -- ─────────────────────────────────────────────────────────────
 -- 2. profiles: Recrear policy de UPDATE con protección de role
 -- ─────────────────────────────────────────────────────────────
--- La policy anterior no tenía WITH CHECK, permitiendo cambiar role.
 
 drop policy if exists "Users can update their own profile." on public.profiles;
 drop policy if exists "Users update own profile" on public.profiles;
@@ -54,9 +99,7 @@ to authenticated
 using (auth.uid() = id)
 with check (
   auth.uid() = id
-  and role is not distinct from (
-    select p.role from public.profiles p where p.id = auth.uid()
-  )
+  and public.check_profile_unmodified(id, role)
 );
 
 -- ─────────────────────────────────────────────────────────────

--- a/supabase/migrations/20260608070000_fix_rls_helpers_hardening.sql
+++ b/supabase/migrations/20260608070000_fix_rls_helpers_hardening.sql
@@ -12,10 +12,13 @@
 --        • blocked_until     (TIMESTAMPTZ) – temporal block
 --        • grupo_tutor       (TEXT)    – tutor group scope
 --        • grupos            (TEXT[])  – group array scope
+--        • estado_cuenta     (TEXT)    – account status
+--        • risk_score        (NUMERIC) – risk score
 --   3. Adds SET search_path = '' to each SECURITY DEFINER function.
---   4. REVOKEs execution from PUBLIC / anon / authenticated.
---   5. GRANTs execution only to postgres (RLS policies execute as
---      table owner = postgres, so the policy can still call them).
+--   4. REVOKEs execution from PUBLIC / anon.
+--   5. GRANTs execution to postgres and authenticated (RLS policies evaluate
+--      as the calling user, so authenticated needs EXECUTE, but being in
+--      private schema prevents RPC exposure).
 --   6. Drops the old public-schema versions.
 --   7. Recreates RLS policies referencing private.* helpers.
 --
@@ -36,7 +39,8 @@ CREATE SCHEMA IF NOT EXISTS private;
 --
 --    Protected fields (10 total):
 --      rol, permisos, alcances, matricula_sase, email, role,
---      seguridad_status, blocked_until, grupo_tutor, grupos
+--      seguridad_status, blocked_until, grupo_tutor, grupos,
+--      estado_cuenta, risk_score
 -- ───────────────────────────────────────────────────────────────
 CREATE OR REPLACE FUNCTION private.check_perfil_usuario_unmodified(
   p_id                uuid,
@@ -49,7 +53,9 @@ CREATE OR REPLACE FUNCTION private.check_perfil_usuario_unmodified(
   p_new_seguridad     text,
   p_new_blocked_until timestamptz,
   p_new_grupo_tutor   text,
-  p_new_grupos        text[]
+  p_new_grupos        text[],
+  p_new_estado_cuenta text,
+  p_new_risk_score    numeric
 )
 RETURNS boolean
 LANGUAGE plpgsql
@@ -74,6 +80,8 @@ BEGIN
     AND p_new_blocked_until IS NOT DISTINCT FROM v_old.blocked_until
     AND p_new_grupo_tutor   IS NOT DISTINCT FROM v_old.grupo_tutor
     AND p_new_grupos        IS NOT DISTINCT FROM v_old.grupos
+    AND p_new_estado_cuenta IS NOT DISTINCT FROM v_old.estado_cuenta
+    AND p_new_risk_score    IS NOT DISTINCT FROM v_old.risk_score
   );
 END;
 $$;
@@ -107,21 +115,22 @@ $$;
 -- 3. Lock down execution on the new private functions
 -- ───────────────────────────────────────────────────────────────
 REVOKE ALL ON FUNCTION private.check_perfil_usuario_unmodified(
-  uuid, text, jsonb, jsonb, text, text, text, text, timestamptz, text, text[]
-) FROM PUBLIC, anon, authenticated;
+  uuid, text, jsonb, jsonb, text, text, text, text, timestamptz, text, text[], text, numeric
+) FROM PUBLIC, anon;
 
 REVOKE ALL ON FUNCTION private.check_profile_unmodified(
   uuid, public.app_role
-) FROM PUBLIC, anon, authenticated;
+) FROM PUBLIC, anon;
 
--- RLS policies run as the table owner (postgres), so grant to postgres only.
+-- RLS policies evaluate as the calling user, so authenticated needs EXECUTE.
+-- The private schema ensures PostgREST does not expose them as RPC.
 GRANT EXECUTE ON FUNCTION private.check_perfil_usuario_unmodified(
-  uuid, text, jsonb, jsonb, text, text, text, text, timestamptz, text, text[]
-) TO postgres;
+  uuid, text, jsonb, jsonb, text, text, text, text, timestamptz, text, text[], text, numeric
+) TO postgres, authenticated;
 
 GRANT EXECUTE ON FUNCTION private.check_profile_unmodified(
   uuid, public.app_role
-) TO postgres;
+) TO postgres, authenticated;
 
 -- ───────────────────────────────────────────────────────────────
 -- 4. Recreate RLS policies using private.* helpers
@@ -148,7 +157,9 @@ WITH CHECK (
     seguridad_status,
     blocked_until,
     grupo_tutor,
-    grupos
+    grupos,
+    estado_cuenta,
+    risk_score
   )
 );
 
@@ -183,11 +194,12 @@ DROP FUNCTION IF EXISTS public.check_profile_unmodified(
 -- ───────────────────────────────────────────────────────────────
 -- ✅ Helpers are in the `private` schema (not RPC-accessible)
 -- ✅ SECURITY DEFINER with SET search_path = '' on both functions
--- ✅ REVOKE ALL FROM PUBLIC, anon, authenticated on both functions
--- ✅ GRANT EXECUTE to postgres only (for RLS policy evaluation)
--- ✅ 10 fields frozen on perfiles_usuario:
+-- ✅ REVOKE ALL FROM PUBLIC, anon on both functions
+-- ✅ GRANT EXECUTE to postgres and authenticated (for RLS policy evaluation)
+-- ✅ 12 fields frozen on perfiles_usuario:
 --      rol, permisos, alcances, matricula_sase, email, role,
---      seguridad_status, blocked_until, grupo_tutor, grupos
+--      seguridad_status, blocked_until, grupo_tutor, grupos,
+--      estado_cuenta, risk_score
 -- ✅ 1 field frozen on profiles: role
 -- ✅ No recursion: helpers use SECURITY DEFINER to bypass RLS
 -- ✅ Old public.check_* functions dropped

--- a/supabase/migrations/20260608070000_fix_rls_helpers_hardening.sql
+++ b/supabase/migrations/20260608070000_fix_rls_helpers_hardening.sql
@@ -1,0 +1,193 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Migration: Harden RLS SECURITY DEFINER helpers
+-- Date:      2026-06-08
+-- PR:        #91 – fix/security-prevent-role-self-escalation
+--
+-- What this fixes (relative to 20260606150001):
+--   1. Moves check_perfil_usuario_unmodified & check_profile_unmodified
+--      from public → private schema so they are NOT exposed as Supabase
+--      RPC endpoints.
+--   2. Adds missing immutable-field checks:
+--        • seguridad_status  (TEXT)    – security block flag
+--        • blocked_until     (TIMESTAMPTZ) – temporal block
+--        • grupo_tutor       (TEXT)    – tutor group scope
+--        • grupos            (TEXT[])  – group array scope
+--   3. Adds SET search_path = '' to each SECURITY DEFINER function.
+--   4. REVOKEs execution from PUBLIC / anon / authenticated.
+--   5. GRANTs execution only to postgres (RLS policies execute as
+--      table owner = postgres, so the policy can still call them).
+--   6. Drops the old public-schema versions.
+--   7. Recreates RLS policies referencing private.* helpers.
+--
+-- Recursion safety:
+--   The helpers use SECURITY DEFINER to bypass RLS when reading
+--   the "old" row, exactly like the 20260606150001 migration.
+--   No SELECT subquery inside the WITH CHECK clause itself, so
+--   no infinite recursion.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ───────────────────────────────────────────────────────────────
+-- 0. Ensure private schema exists (idempotent)
+-- ───────────────────────────────────────────────────────────────
+CREATE SCHEMA IF NOT EXISTS private;
+
+-- ───────────────────────────────────────────────────────────────
+-- 1. Create hardened helper: private.check_perfil_usuario_unmodified
+--
+--    Protected fields (10 total):
+--      rol, permisos, alcances, matricula_sase, email, role,
+--      seguridad_status, blocked_until, grupo_tutor, grupos
+-- ───────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION private.check_perfil_usuario_unmodified(
+  p_id                uuid,
+  p_new_rol           text,
+  p_new_permisos      jsonb,
+  p_new_alcances      jsonb,
+  p_new_matricula     text,
+  p_new_email         text,
+  p_new_role          text,
+  p_new_seguridad     text,
+  p_new_blocked_until timestamptz,
+  p_new_grupo_tutor   text,
+  p_new_grupos        text[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_old public.perfiles_usuario;
+BEGIN
+  SELECT * INTO v_old FROM public.perfiles_usuario WHERE id = p_id;
+  IF NOT FOUND THEN
+    RETURN true;                      -- new row → allow INSERT policies
+  END IF;
+  RETURN (
+        p_new_rol           IS NOT DISTINCT FROM v_old.rol
+    AND p_new_permisos      IS NOT DISTINCT FROM v_old.permisos
+    AND p_new_alcances      IS NOT DISTINCT FROM v_old.alcances
+    AND p_new_matricula     IS NOT DISTINCT FROM v_old.matricula_sase
+    AND p_new_email         IS NOT DISTINCT FROM v_old.email
+    AND p_new_role          IS NOT DISTINCT FROM v_old.role
+    AND p_new_seguridad     IS NOT DISTINCT FROM v_old.seguridad_status
+    AND p_new_blocked_until IS NOT DISTINCT FROM v_old.blocked_until
+    AND p_new_grupo_tutor   IS NOT DISTINCT FROM v_old.grupo_tutor
+    AND p_new_grupos        IS NOT DISTINCT FROM v_old.grupos
+  );
+END;
+$$;
+
+-- ───────────────────────────────────────────────────────────────
+-- 2. Create hardened helper: private.check_profile_unmodified
+--
+--    Protected fields: role (app_role enum)
+-- ───────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION private.check_profile_unmodified(
+  p_id       uuid,
+  p_new_role public.app_role
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_old_role public.app_role;
+BEGIN
+  SELECT role INTO v_old_role FROM public.profiles WHERE id = p_id;
+  IF NOT FOUND THEN
+    RETURN true;
+  END IF;
+  RETURN p_new_role IS NOT DISTINCT FROM v_old_role;
+END;
+$$;
+
+-- ───────────────────────────────────────────────────────────────
+-- 3. Lock down execution on the new private functions
+-- ───────────────────────────────────────────────────────────────
+REVOKE ALL ON FUNCTION private.check_perfil_usuario_unmodified(
+  uuid, text, jsonb, jsonb, text, text, text, text, timestamptz, text, text[]
+) FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION private.check_profile_unmodified(
+  uuid, public.app_role
+) FROM PUBLIC, anon, authenticated;
+
+-- RLS policies run as the table owner (postgres), so grant to postgres only.
+GRANT EXECUTE ON FUNCTION private.check_perfil_usuario_unmodified(
+  uuid, text, jsonb, jsonb, text, text, text, text, timestamptz, text, text[]
+) TO postgres;
+
+GRANT EXECUTE ON FUNCTION private.check_profile_unmodified(
+  uuid, public.app_role
+) TO postgres;
+
+-- ───────────────────────────────────────────────────────────────
+-- 4. Recreate RLS policies using private.* helpers
+-- ───────────────────────────────────────────────────────────────
+
+-- 4a. perfiles_usuario UPDATE policy
+DROP POLICY IF EXISTS "Usuarios actualizan su propio perfil" ON public.perfiles_usuario;
+
+CREATE POLICY "Usuarios actualizan su propio perfil"
+ON public.perfiles_usuario
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = id)
+WITH CHECK (
+  auth.uid() = id
+  AND private.check_perfil_usuario_unmodified(
+    id,
+    rol,
+    permisos,
+    alcances,
+    matricula_sase,
+    email,
+    role,
+    seguridad_status,
+    blocked_until,
+    grupo_tutor,
+    grupos
+  )
+);
+
+-- 4b. profiles UPDATE policy
+DROP POLICY IF EXISTS "Users can update their own profile." ON public.profiles;
+DROP POLICY IF EXISTS "Users update own profile" ON public.profiles;
+
+CREATE POLICY "Users can update their own profile."
+ON public.profiles
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = id)
+WITH CHECK (
+  auth.uid() = id
+  AND private.check_profile_unmodified(id, role)
+);
+
+-- ───────────────────────────────────────────────────────────────
+-- 5. Drop the old public-schema helper functions
+--    (They are no longer referenced by any policy.)
+-- ───────────────────────────────────────────────────────────────
+DROP FUNCTION IF EXISTS public.check_perfil_usuario_unmodified(
+  uuid, text, jsonb, jsonb, text, text, text
+);
+
+DROP FUNCTION IF EXISTS public.check_profile_unmodified(
+  uuid, public.app_role
+);
+
+-- ───────────────────────────────────────────────────────────────
+-- 6. Verification comments
+-- ───────────────────────────────────────────────────────────────
+-- ✅ Helpers are in the `private` schema (not RPC-accessible)
+-- ✅ SECURITY DEFINER with SET search_path = '' on both functions
+-- ✅ REVOKE ALL FROM PUBLIC, anon, authenticated on both functions
+-- ✅ GRANT EXECUTE to postgres only (for RLS policy evaluation)
+-- ✅ 10 fields frozen on perfiles_usuario:
+--      rol, permisos, alcances, matricula_sase, email, role,
+--      seguridad_status, blocked_until, grupo_tutor, grupos
+-- ✅ 1 field frozen on profiles: role
+-- ✅ No recursion: helpers use SECURITY DEFINER to bypass RLS
+-- ✅ Old public.check_* functions dropped

--- a/supabase/migrations/20260608070000_fix_rls_helpers_hardening.sql
+++ b/supabase/migrations/20260608070000_fix_rls_helpers_hardening.sql
@@ -93,7 +93,7 @@ $$;
 -- ───────────────────────────────────────────────────────────────
 CREATE OR REPLACE FUNCTION private.check_profile_unmodified(
   p_id       uuid,
-  p_new_role public.app_role
+  p_new_role text
 )
 RETURNS boolean
 LANGUAGE plpgsql
@@ -101,9 +101,9 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-  v_old_role public.app_role;
+  v_old_role text;
 BEGIN
-  SELECT role INTO v_old_role FROM public.profiles WHERE id = p_id;
+  SELECT role::text INTO v_old_role FROM public.profiles WHERE id = p_id;
   IF NOT FOUND THEN
     RETURN true;
   END IF;
@@ -119,8 +119,11 @@ REVOKE ALL ON FUNCTION private.check_perfil_usuario_unmodified(
 ) FROM PUBLIC, anon;
 
 REVOKE ALL ON FUNCTION private.check_profile_unmodified(
-  uuid, public.app_role
+  uuid, text
 ) FROM PUBLIC, anon;
+
+-- PostgreSQL requires USAGE on the schema to access functions within it
+GRANT USAGE ON SCHEMA private TO postgres, authenticated;
 
 -- RLS policies evaluate as the calling user, so authenticated needs EXECUTE.
 -- The private schema ensures PostgREST does not expose them as RPC.
@@ -129,7 +132,7 @@ GRANT EXECUTE ON FUNCTION private.check_perfil_usuario_unmodified(
 ) TO postgres, authenticated;
 
 GRANT EXECUTE ON FUNCTION private.check_profile_unmodified(
-  uuid, public.app_role
+  uuid, text
 ) TO postgres, authenticated;
 
 -- ───────────────────────────────────────────────────────────────
@@ -174,7 +177,7 @@ TO authenticated
 USING (auth.uid() = id)
 WITH CHECK (
   auth.uid() = id
-  AND private.check_profile_unmodified(id, role)
+  AND private.check_profile_unmodified(id, role::text)
 );
 
 -- ───────────────────────────────────────────────────────────────
@@ -185,9 +188,18 @@ DROP FUNCTION IF EXISTS public.check_perfil_usuario_unmodified(
   uuid, text, jsonb, jsonb, text, text, text
 );
 
-DROP FUNCTION IF EXISTS public.check_profile_unmodified(
-  uuid, public.app_role
-);
+DO $$
+BEGIN
+  -- We use dynamic SQL to avoid parsing errors if public.app_role does not exist
+  EXECUTE 'DROP FUNCTION IF EXISTS public.check_profile_unmodified(uuid, public.app_role)';
+EXCEPTION WHEN OTHERS THEN
+  -- Fallback if the type doesn't exist or it was using text
+  BEGIN
+    EXECUTE 'DROP FUNCTION IF EXISTS public.check_profile_unmodified(uuid, text)';
+  EXCEPTION WHEN OTHERS THEN
+    NULL;
+  END;
+END $$;
 
 -- ───────────────────────────────────────────────────────────────
 -- 6. Verification comments

--- a/tests/DashboardOrientacion.test.tsx
+++ b/tests/DashboardOrientacion.test.tsx
@@ -114,7 +114,7 @@ describe("Dashboard Orientacion v2", () => {
     await screen.findByRole("heading", { name: "Ana Rivera" });
     expect(screen.getByText(/Bandeja de casos/i)).toBeInTheDocument();
     expect(screen.getByText(/Historial institucional/i)).toBeInTheDocument();
-  });
+  }, 15000);
 
   it("abre un caso sugerido y solicita diagnóstico", async () => {
     render(<DashboardOrientacion />);
@@ -126,5 +126,5 @@ describe("Dashboard Orientacion v2", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /enviar solicitud/i }));
     await waitFor(() => expect(mocks.requestDiagnosis).toHaveBeenCalled());
-  });
+  }, 15000);
 });

--- a/tests/DashboardTrabajoSocial.test.tsx
+++ b/tests/DashboardTrabajoSocial.test.tsx
@@ -51,14 +51,14 @@ describe("DashboardTrabajoSocial", () => {
     expect(screen.getByRole("heading", { name: /Intervención en campo/i })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /Casos asignados/i })).toBeInTheDocument();
     expect(screen.getAllByText("Alumno Sin Respuesta").length).toBeGreaterThan(0);
-  });
+  }, 15000);
 
   it("highlights three unanswered citatorios as a critical institutional rule", () => {
     render(<DashboardTrabajoSocial />);
 
     expect(screen.getAllByText(/3 citatorios sin respuesta/i).length).toBeGreaterThan(0);
     expect(screen.getByRole("alert")).toHaveTextContent(/Padres no han respondido a 3 citatorios/i);
-  });
+  }, 15000);
 
   it("registers a quick family contact without creating a new incident", () => {
     render(<DashboardTrabajoSocial />);
@@ -70,7 +70,7 @@ describe("DashboardTrabajoSocial", () => {
 
     expect(screen.getByText("Contacto familiar registrado (registro local - pendiente de persistencia institucional)")).toBeInTheDocument();
     expect(screen.getByText("Tutor confirma llamada de seguimiento.")).toBeInTheDocument();
-  });
+  }, 15000);
 
   it("blocks final closure and exposes escalation path instead", () => {
     render(<DashboardTrabajoSocial />);
@@ -78,5 +78,5 @@ describe("DashboardTrabajoSocial", () => {
     expect(screen.getByText(/Cierre final bloqueado/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Escalar a Dirección \(en preparación\)/i })).toBeEnabled();
     expect(screen.queryByRole("button", { name: /Cerrar caso/i })).not.toBeInTheDocument();
-  });
+  }, 15000);
 });

--- a/tests/IntegrationFlow.test.tsx
+++ b/tests/IntegrationFlow.test.tsx
@@ -62,6 +62,7 @@ vi.mock("../src/supabase/client", () => {
   });
 
   mocks.update.mockReturnValue({ eq: mocks.eq });
+  mocks.insert.mockReturnValue({ select: mocks.select });
 
   return {
     supabase: {
@@ -130,7 +131,6 @@ describe("Integration: Docente -> Direccion Flow", () => {
       },
     ];
 
-    mocks.insert.mockResolvedValue({ error: null });
     // No usar mockResolvedValue en eq, ya que rompe la cadena (order, limit, etc)
     // mocks.eq ya tiene una implementación por defecto que devuelve un thenable con queryChain
   });

--- a/tests/IntegrationFlow.test.tsx
+++ b/tests/IntegrationFlow.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import { AppProvider, useApp } from "../src/store";
@@ -156,5 +157,10 @@ describe("Integration: Docente -> Direccion Flow", () => {
     await waitFor(() => {
       expect(mocks.insert).toHaveBeenCalled();
     });
-  });
+
+    await waitFor(() => {
+      const kpiElement = screen.getByText(/Poblacion total atendida/i).closest("div");
+      expect(kpiElement).toHaveTextContent("1");
+    });
+  }, 15000);
 });

--- a/tests/SasitoExperience.test.ts
+++ b/tests/SasitoExperience.test.ts
@@ -159,4 +159,28 @@ describe("Sasito Experiencia Institucional", () => {
     expect(result.riesgo).toBe("verde");
     expect(result.tipo).toBe("academica");
   });
+
+  // --- Plural and routing tests ---
+
+  it('"armas" SÍ activa riesgo rojo', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "trajo armas" });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it('"golpes" SÍ activa riesgo rojo', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "hubo golpes" });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it('"empujones" SÍ activa riesgo rojo', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "se dieron empujones" });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it("salida_aula_sin_autorizacion + posible arma → protocolo de seguridad", () => {
+    const result = classifyIncident({ conducta: "salida_aula_sin_autorizacion", descripcion: "posible arma" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+    expect(result.experienciaId).toBe("posible_riesgo_seguridad");
+  });
 });

--- a/tests/SasitoExperience.test.ts
+++ b/tests/SasitoExperience.test.ts
@@ -82,4 +82,59 @@ describe("Sasito Experiencia Institucional", () => {
     expect(result.revisionHumana).toBe(true);
     expect(result.accionesRecomendadas).toEqual([HUMAN_REVIEW_ACTION]);
   });
+
+  // --- False positive tests - substring matching ---
+
+  it('"armar equipo" NO activa riesgo rojo (falso positivo de arma)', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "vamos a armar equipos" });
+    expect(result.riesgo).not.toBe("rojo");
+  });
+
+  it('"desarmar material" NO activa riesgo rojo', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "desarmar el material" });
+    expect(result.riesgo).not.toBe("rojo");
+  });
+
+  // --- True positive tests ---
+
+  it('"posible arma" SÍ activa riesgo rojo', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "posible arma" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it('"trae arma" SÍ activa riesgo rojo (token completo)', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "trae arma" });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it('"arma blanca" SÍ activa riesgo rojo', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "arma blanca" });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  // --- Priority tests - red safety overrides academic ---
+
+  it("no_trabaja_en_clase + posible arma → riesgo rojo y tipo seguridad", () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "posible arma en mochila" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+    expect(result.requiereEscalamiento).toBe(true);
+    expect(result.accionesRecomendadas).toEqual(expect.arrayContaining([
+      expect.stringContaining("protocolo"),
+    ]));
+  });
+
+  it("no_trabaja_en_clase + fuego → riesgo rojo y tipo seguridad", () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "posible fuego en laboratorio" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+  });
+
+  it("no_trabaja_en_clase sin señal roja → académico verde", () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase" });
+    expect(result.riesgo).toBe("verde");
+    expect(result.tipo).toBe("academica");
+  });
 });

--- a/tests/SasitoExperience.test.ts
+++ b/tests/SasitoExperience.test.ts
@@ -114,6 +114,28 @@ describe("Sasito Experiencia Institucional", () => {
     expect(result.riesgo).toBe("rojo");
   });
 
+  // --- Punctuation boundary tests ---
+
+  it('"trae arma." SÍ activa riesgo rojo (puntuación)', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "trae arma." });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it('"arma," SÍ activa riesgo rojo (puntuación)', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "arma," });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it('"posible fuego;" SÍ activa riesgo rojo (puntuación)', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "posible fuego;" });
+    expect(result.riesgo).toBe("rojo");
+  });
+
+  it('"hubo golpe," SÍ activa riesgo rojo (puntuación)', () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase", descripcion: "hubo golpe," });
+    expect(result.riesgo).toBe("rojo");
+  });
+
   // --- Priority tests - red safety overrides academic ---
 
   it("no_trabaja_en_clase + posible arma → riesgo rojo y tipo seguridad", () => {

--- a/tests/SasitoExperience.test.ts
+++ b/tests/SasitoExperience.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { classifyIncident } from "../src/lib/sasito/classifyIncident";
+import { HUMAN_REVIEW_ACTION } from "../src/lib/sasito/riskRules";
+
+describe("Sasito Experiencia Institucional", () => {
+  it("clasifica no_trabaja_en_clase como academica verde", () => {
+    const result = classifyIncident({ conducta: "no_trabaja_en_clase" });
+
+    expect(result.tipo).toBe("academica");
+    expect(result.riesgo).toBe("verde");
+    expect(result.requiereEscalamiento).toBe(false);
+  });
+
+  it("clasifica salida_aula_sin_autorizacion con reincidencia como seguridad amarillo", () => {
+    const result = classifyIncident({
+      conducta: "salida_aula_sin_autorizacion",
+      reincidenciasPrevias: 1,
+    });
+
+    expect(result.tipo).toBe("seguridad");
+    expect(result.riesgo).toBe("amarillo");
+    expect(result.requiereEscalamiento).toBe(false);
+  });
+
+  it("clasifica agresion_fisica como seguridad rojo y requiere escalamiento", () => {
+    const result = classifyIncident({ conducta: "agresion_fisica" });
+
+    expect(result.tipo).toBe("seguridad");
+    expect(result.riesgo).toBe("rojo");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it("clasifica posible_arma como seguridad rojo y requiere escalamiento", () => {
+    const result = classifyIncident({ conducta: "posible_arma" });
+
+    expect(result.tipo).toBe("seguridad");
+    expect(result.riesgo).toBe("rojo");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it("clasifica fuego como seguridad rojo y requiere escalamiento", () => {
+    const result = classifyIncident({ conducta: "fuego" });
+
+    expect(result.tipo).toBe("seguridad");
+    expect(result.riesgo).toBe("rojo");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it("clasifica alumno_no_localizado como seguridad rojo y requiere escalamiento", () => {
+    const result = classifyIncident({ conducta: "alumno_no_localizado" });
+
+    expect(result.tipo).toBe("seguridad");
+    expect(result.riesgo).toBe("rojo");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it("clasifica citatorio_sin_respuesta con reincidencia como familiar amarillo", () => {
+    const result = classifyIncident({
+      conducta: "citatorio_sin_respuesta",
+      esReincidencia: true,
+    });
+
+    expect(result.tipo).toBe("familiar");
+    expect(result.riesgo).toBe("amarillo");
+    expect(result.requiereEscalamiento).toBe(false);
+  });
+
+  it("clasifica conducta_positiva como seguimiento verde", () => {
+    const result = classifyIncident({ conducta: "conducta_positiva" });
+
+    expect(result.tipo).toBe("seguimiento");
+    expect(result.riesgo).toBe("verde");
+    expect(result.requiereEscalamiento).toBe(false);
+  });
+
+  it("conducta desconocida no inventa acciones y pide revision humana", () => {
+    const result = classifyIncident({ conducta: "situacion no prevista en catalogo" });
+
+    expect(result.tipo).toBe("seguimiento");
+    expect(result.riesgo).toBe("verde");
+    expect(result.requiereEscalamiento).toBe(false);
+    expect(result.revisionHumana).toBe(true);
+    expect(result.accionesRecomendadas).toEqual([HUMAN_REVIEW_ACTION]);
+  });
+});

--- a/tests/SasitoExperience.test.ts
+++ b/tests/SasitoExperience.test.ts
@@ -183,4 +183,43 @@ describe("Sasito Experiencia Institucional", () => {
     expect(result.tipo).toBe("seguridad");
     expect(result.experienciaId).toBe("posible_riesgo_seguridad");
   });
+
+  // --- No base experience red signal tests ---
+
+  it('"trajo armas" → rojo / seguridad / protocolo', () => {
+    const result = classifyIncident({ descripcion: "trajo armas" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it('"hubo golpes" → rojo / seguridad / protocolo', () => {
+    const result = classifyIncident({ descripcion: "hubo golpes" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it('"hubo empujones" → rojo / seguridad / protocolo', () => {
+    const result = classifyIncident({ descripcion: "hubo empujones" });
+    expect(result.riesgo).toBe("rojo");
+    expect(result.tipo).toBe("seguridad");
+    expect(result.requiereEscalamiento).toBe(true);
+  });
+
+  it('"armar equipo" → no rojo', () => {
+    const result = classifyIncident({ descripcion: "armar equipo" });
+    expect(result.riesgo).not.toBe("rojo");
+  });
+
+  it('"desarmar material" → no rojo', () => {
+    const result = classifyIncident({ descripcion: "desarmar material" });
+    expect(result.riesgo).not.toBe("rojo");
+  });
+
+  it('"comentario no reconocido" → unknown/verde/revisión humana', () => {
+    const result = classifyIncident({ descripcion: "comentario no reconocido" });
+    expect(result.riesgo).toBe("verde");
+    expect(result.revisionHumana).toBe(true);
+  });
 });

--- a/tests/SasitoExperience.test.ts
+++ b/tests/SasitoExperience.test.ts
@@ -187,38 +187,38 @@ describe("Sasito Experiencia Institucional", () => {
   // --- No base experience red signal tests ---
 
   it('"trajo armas" → rojo / seguridad / protocolo', () => {
-    const result = classifyIncident({ descripcion: "trajo armas" });
+    const result = classifyIncident({ conducta: "otra", descripcion: "trajo armas" });
     expect(result.riesgo).toBe("rojo");
     expect(result.tipo).toBe("seguridad");
     expect(result.requiereEscalamiento).toBe(true);
   });
 
   it('"hubo golpes" → rojo / seguridad / protocolo', () => {
-    const result = classifyIncident({ descripcion: "hubo golpes" });
+    const result = classifyIncident({ conducta: "otra", descripcion: "hubo golpes" });
     expect(result.riesgo).toBe("rojo");
     expect(result.tipo).toBe("seguridad");
     expect(result.requiereEscalamiento).toBe(true);
   });
 
   it('"hubo empujones" → rojo / seguridad / protocolo', () => {
-    const result = classifyIncident({ descripcion: "hubo empujones" });
+    const result = classifyIncident({ conducta: "otra", descripcion: "hubo empujones" });
     expect(result.riesgo).toBe("rojo");
     expect(result.tipo).toBe("seguridad");
     expect(result.requiereEscalamiento).toBe(true);
   });
 
   it('"armar equipo" → no rojo', () => {
-    const result = classifyIncident({ descripcion: "armar equipo" });
+    const result = classifyIncident({ conducta: "otra", descripcion: "armar equipo" });
     expect(result.riesgo).not.toBe("rojo");
   });
 
   it('"desarmar material" → no rojo', () => {
-    const result = classifyIncident({ descripcion: "desarmar material" });
+    const result = classifyIncident({ conducta: "otra", descripcion: "desarmar material" });
     expect(result.riesgo).not.toBe("rojo");
   });
 
   it('"comentario no reconocido" → unknown/verde/revisión humana', () => {
-    const result = classifyIncident({ descripcion: "comentario no reconocido" });
+    const result = classifyIncident({ conducta: "otra", descripcion: "comentario no reconocido" });
     expect(result.riesgo).toBe("verde");
     expect(result.revisionHumana).toBe(true);
   });


### PR DESCRIPTION
## Resumen
Resuelve la vulnerabilidad crítica P0 de autoescalamiento de roles, permisos y alcances.

## Problema
En `public.perfiles_usuario`, la política RLS `"Usuarios actualizan su propio perfil"` utilizaba la comparación:
`NOT (rol IS DISTINCT FROM rol)`
Dado que `WITH CHECK` evalúa la fila propuesta (NEW), esto se traducía en comparar `NEW.rol` con `NEW.rol`, lo cual siempre es verdadero y permitía a cualquier usuario autenticado actualizar su propio rol. En `public.profiles`, la política de actualización permitía cambios ilimitados de cualquier columna al usuario propietario.

## Cambios
- **Migración SQL:** Se añade `supabase/migrations/20260606000000_prevent_role_self_escalation.sql` para endurecer las políticas de actualización (`UPDATE`) en `perfiles_usuario` y `profiles`. Las columnas `rol`, `role`, `permisos`, `alcances`, `email` y `matricula_sase` ahora son de solo lectura para el propietario (validadas contra los valores existentes mediante subconsultas).
- **Documentación:** Se añade un runbook de verificación detallado en `docs/security/role-self-escalation-test.md`.

## Validaciones
- `pnpm lint`
- `pnpm type-check`
- `pnpm test` (pasó exitosamente)
- `pnpm build`
