### PR TITLE
fix(rls): harden institutional policy follow-up

### DIFF
--- a/specs/008-rls-tablas-institucionales/quickstart.md
+++ b/specs/008-rls-tablas-institucionales/quickstart.md
@@ -1,44 +1,75 @@
-# Quickstart - 008 RLS Tablas Institucionales
+# Quickstart - QA de RLS institucional
 
-## 1. Migraciones
+Estado: Implementado / en QA
 
-```bash
-# Copiar WIP sos a migrations real
-cp _wip/sos/20260503220000_sos_auto_escalation.sql \
-   supabase/migrations/20260612000001_sos_alerts_y_auto_escalation.sql
+Este documento es un relevo de validación local. No autoriza merge, deploy ni
+aplicación manual sobre un proyecto hospedado.
 
-# La migracion 002 se crea desde cero con RLS policies
-# Ver spec.md para el contenido exacto
-```
+## 1. Alcance a validar
 
-## 2. Frontend
+- Migración real:
+  `supabase/migrations/20260701000000_add_rls_policies.sql`.
+- Tablas RLS: `interventions_log`, `evidence_log`, `citas_padres`,
+  `contacts_log` y `activities_log`.
+- SOS canónico: `alertas_emergencia`; `sase_alerts` no debe participar en el
+  flujo operativo de SOS.
+- `evidence_log` no tiene ni requiere `student_id`.
+- UPDATE de cliente solo aplica a `interventions_log` y `citas_padres`.
+- UPDATE de `perfiles_usuario` solo permite `nombre_completo`, `telefono` y
+  `preferencias_dashboard`.
 
-```bash
-# Regenerar tipos
-supabase gen types typescript --local > src/supabase/types.ts
+## 2. Puertas automáticas
 
-# Editar useInstitutionalActions.ts para quitar todos los "as any"
-# Verificar con:
-pnpm type-check
-pnpm test
-```
-
-## 3. Verificacion
+Ejecutar en entorno local controlado:
 
 ```bash
-# Migraciones
-supabase db start
-supabase migration up
 ./scripts/audit-migrations.sh
+supabase db start
 supabase db lint --local
 
-# Frontend
 pnpm lint
 pnpm type-check
 pnpm test
 pnpm build
 ```
 
-## 4. Prueba manual
+No usar `scripts/test_auth.mjs`, `scripts/test_rls.mjs`,
+`scripts/mass_invite_staff.js` ni `scripts/seed-institucional.ts`: apuntan a
+entornos hospedados o mutan datos con privilegios.
 
-Ver spec.md — prueba end-to-end con login de Direccion para escalar, SOS, cerrar caso.
+## 3. Escenarios RLS
+
+Validar con usuarios de prueba locales y evidencia auditable:
+
+1. Un actor institucional activo puede insertar registros propios.
+2. Un actor institucional no privilegiado solo puede leer sus registros.
+3. `directivo`, `subdireccion`, `developer` y `system_admin` pueden realizar
+   SELECT global.
+4. En `citas_padres`, el creador, `orientacion` y los roles privilegiados
+   pueden consultar; otros roles no obtienen lectura global.
+5. Solo los roles autorizados pueden actualizar `interventions_log` y
+   `citas_padres`.
+6. `evidence_log`, `contacts_log` y `activities_log` rechazan UPDATE desde el
+   cliente autenticado.
+7. Un perfil inexistente, inactivo, bloqueado o con rol fuera del catálogo es
+   rechazado.
+8. Un usuario autenticado no puede modificar su rol ni estados de cuenta o
+   seguridad en `perfiles_usuario`.
+
+## 4. Flujo funcional
+
+1. Registrar una acción institucional y confirmar persistencia en la tabla
+   correspondiente.
+2. Registrar evidencia y confirmar que el INSERT no intenta enviar
+   `student_id`.
+3. Programar una cita y comprobar las reglas de creador, `orientacion` y roles
+   privilegiados.
+4. Crear, reconocer y resolver un SOS desde el flujo local.
+5. Confirmar que el SOS se persiste en `alertas_emergencia` y que no se consulta
+   ni escribe `sase_alerts` como parte del flujo operativo.
+
+## 5. Cierre de QA
+
+Registrar comandos ejecutados, resultados, identidades de prueba y cualquier
+desviación entre `spec.md` y la migración. Hasta cerrar esas evidencias, el
+expediente permanece en estado implementado/en QA.

--- a/specs/008-rls-tablas-institucionales/spec.md
+++ b/specs/008-rls-tablas-institucionales/spec.md
@@ -1,154 +1,121 @@
-# Spec 008 - RLS y tablas institucionales faltantes
+# Spec 008 - RLS de tablas institucionales
 
-Estado: Pendiente de implementacion
+Estado: Implementado / en QA
+
+La implementación está en la rama `fix/rls-institutional-action-tables`. No se
+considera desplegada ni aplicada a producción hasta completar QA y el flujo de
+revisión autorizado.
 
 ## Problema
 
-El frontend escribe en 6 tablas institucionales que fallan silenciosamente:
+Las tablas `interventions_log`, `evidence_log`, `citas_padres`, `contacts_log`
+y `activities_log` fueron creadas por
+`supabase/migrations/20260425200000_legacy_tables_sync.sql` con RLS habilitado,
+pero sin las políticas necesarias para las acciones institucionales.
 
-| Tabla | Creada | RLS policies | Frontend escribe | Resultado |
-|-------|--------|-------------|-----------------|-----------|
-| `interventions_log` | `20260425200000_legacy_tables_sync.sql` | 0 (RLS ON sin policies) | 8 funciones via `as any` | Query rechazada por RLS |
-| `evidence_log` | ídem | 0 (RLS ON sin policies) | `registerEvidence()` via `as any` | Query rechazada |
-| `citas_padres` | ídem | 0 (RLS ON sin policies) | `scheduleFollowUp()` via `as any` | Query rechazada |
-| `contacts_log` | ídem | 0 (RLS ON sin policies) | `orientacionApi.ts` | Query rechazada |
-| `sos_alerts` | Solo en `_wip/sos/` (no migrado) | No aplica | 3 funciones via `as any` | Tabla no existe |
-| `activities_log` | `20260425200000_legacy_tables_sync.sql` | 0 (RLS ON sin policies) | Solo store | Query rechazada |
+El expediente también conservaba dos supuestos incorrectos:
 
-**Consecuencia:** `useInstitutionalActions()` ejecuta `catch` silencioso en todas sus 9 funciones. Direccion, Prefectura y cualquier rol que use escalamiento, SOS, cierre, evidencia o seguimiento cree que la operacion funciono (toast.success) pero los datos nunca se persisten.
+- El flujo SOS no usa `sase_alerts` como tabla operativa.
+  `alertas_emergencia` es la fuente canónica; `sase_alerts` queda como
+  observabilidad fuera de este alcance.
+- `evidence_log` no tiene una columna `student_id`; la relación contextual con
+  un alumno se conserva en la auditoría y no debe inventarse en el esquema.
 
-## Causa raiz
+## Implementación real
 
-La migracion `20260425200000_legacy_tables_sync.sql` creo las tablas con `CREATE TABLE IF NOT EXISTS` y habilito RLS (`ALTER TABLE ... ENABLE ROW LEVEL SECURITY`), pero **nunca agrego `CREATE POLICY`**. Sin policies, RLS bloquea toda operacion.
+La migración de este cambio es:
 
-El frontend uso `as any` para que TypeScript no se queje, pero Supabase igual rechaza las queries.
+`supabase/migrations/20260701000000_add_rls_policies.sql`
 
-`sos_alerts` quedo en `_wip/sos/` y nunca se migro.
+La migración:
 
-## Alcance
+- habilita y define RLS para las cinco tablas institucionales;
+- agrega el helper privado `private.is_institutional_actor(text[])`;
+- limita los privilegios de `UPDATE` por tabla y columna;
+- endurece `UPDATE` sobre `perfiles_usuario` para impedir autoescalamiento.
 
-### Backend (orden de migracion)
+No se crea ni se migra `sase_alerts` dentro de este cambio.
 
-1. **Migrar `sos_alerts` desde `_wip/sos/` a `supabase/migrations/`**
-   - Mover `_wip/sos/20260503220000_sos_auto_escalation.sql` a `supabase/migrations/20260612000001_sos_alerts_y_auto_escalation.sql`
-   - La migracion ya contiene: CREATE TABLE, RLS, auto_escalate_sos(), pg_cron schedule, trigger auto_resolve
+## Autorización fail-closed
 
-2. **Agregar RLS policies a `interventions_log`**
-   - `interventions_log_insert_institutional`: INSERT permitido si `auth.uid()` es personal institucional (rol en perfiles_usuario != 'alumno' y != null)
-   - `interventions_log_select_own`: SELECT donde `user_id = auth.uid()` O el rol es direccion/subdireccion/developer/system_admin (ven todo)
-   - `interventions_log_update_institutional`: UPDATE solo para direccion/subdireccion/developer/system_admin
+`private.is_institutional_actor(text[])` usa `auth.uid()` y
+`perfiles_usuario.rol` como fuente de autorización. Solo devuelve acceso cuando:
 
-3. **Agregar RLS policies a `evidence_log`**
-   - `evidence_log_insert_institutional`: INSERT si rol institucional
-   - `evidence_log_select_own`: SELECT propio + direccion ve todo
+- existe un perfil cuyo `id` coincide con `auth.uid()`;
+- `estado_cuenta = 'activo'`;
+- `seguridad_status = 'active'`;
+- el rol pertenece al catálogo institucional admitido;
+- el rol pertenece además al arreglo solicitado por la política.
 
-4. **Agregar RLS policies a `citas_padres`**
-   - `citas_padres_insert_institutional`: INSERT si rol institucional
-   - `citas_padres_select_institutional`: SELECT si rol institucional (todos ven citas)
-   - `citas_padres_update_institutional`: UPDATE solo para orientacion/direccion/developer
+La ausencia de sesión, perfil, rol reconocido o cuenta activa produce
+denegación. El helper es `SECURITY DEFINER`, usa `search_path = ''`, vive en el
+schema `private` y solo concede ejecución a `authenticated`.
 
-5. **Agregar RLS policies a `contacts_log`**
-   - `contacts_log_insert_institutional`: INSERT si rol institucional
-   - `contacts_log_select_own`: SELECT propio + direccion/developer ve todo
+## Reglas RLS
 
-6. **Agregar RLS policies a `activities_log`**
-   - `activities_log_insert_institutional`: INSERT si rol institucional
-   - `activities_log_select_own`: SELECT propio + direccion/developer ve todo
+Los roles con lectura global explícita son `directivo`, `subdireccion`,
+`developer` y `system_admin`. Los demás roles institucionales solo consultan
+registros propios, salvo la regla específica de `citas_padres`.
 
-### Frontend
+| Tabla | SELECT | INSERT | UPDATE |
+|---|---|---|---|
+| `interventions_log` | Propio por `user_id`; lectura global para roles privilegiados | Actor institucional con `user_id = auth.uid()`; la FK valida `student_id` cuando se informa | Solo roles privilegiados; columnas `reason`, `result`, `notes` |
+| `evidence_log` | Propio por `user_id`; lectura global para roles privilegiados | Actor institucional con `user_id = auth.uid()` | No permitido |
+| `contacts_log` | Propio por `user_id`; lectura global para roles privilegiados | Actor institucional con `user_id = auth.uid()`; la FK valida `student_id` cuando se informa | No permitido |
+| `activities_log` | Propio por `user_id`; lectura global para roles privilegiados | Actor institucional con `user_id = auth.uid()` | No permitido |
+| `citas_padres` | Creador por `creado_por`; lectura institucional ampliada para `orientacion` y roles privilegiados | Actor institucional con `creado_por = auth.uid()`; la FK valida `alumno_id` | `orientacion` y roles privilegiados; columnas `estado`, `fecha_cita`, `motivo`, `observaciones` |
 
-7. **Tipar `useInstitutionalActions.ts`** — quitar los 51 `as any`
-   - Eliminar `as any` en todas las llamadas a `supabase.from("interventions_log" as any)`
-   - Eliminar `as any` en `supabase.from("sos_alerts" as any)`
-   - Eliminar `as any` en `supabase.from("citas_padres" as any)`
-   - Eliminar `as any` en `supabase.from("evidence_log" as any)`
-   - Requisito: regenerar tipos con `supabase gen types typescript --local > src/supabase/types.ts`
+Solo `interventions_log` y `citas_padres` conservan privilegios de `UPDATE`
+para el cliente autenticado.
 
-8. **`registerEvidence()` en `useInstitutionalActions.ts`**
-   - Agregar campo `student_id` al INSERT (hoy omite student_id, la tabla lo tiene como FK opcional)
+## Endurecimiento de perfiles
 
-9. **Limpiar `evidence_log` INSERT en `store.tsx`**
-   - Buscar y tipar correctamente la referencia en `src/store.tsx:260`
+La migración revoca el privilegio general de `UPDATE` sobre
+`perfiles_usuario` para `public`, `anon` y `authenticated`. Después concede a
+`authenticated` únicamente:
+
+- `nombre_completo`;
+- `telefono`;
+- `preferencias_dashboard`.
+
+No se concede actualización de `rol`, `role`, estados de cuenta, atributos de
+seguridad ni otros campos que permitan autoescalamiento.
+
+## Flujo SOS canónico
+
+`src/hooks/useInstitutionalActions.ts` registra, reconoce y resuelve SOS en
+`alertas_emergencia`. El contexto del alumno se conserva en `metadata`, y
+`interventions_log` mantiene el registro histórico institucional cuando
+corresponde.
+
+`sase_alerts` no forma parte del alcance operativo de SOS en este cambio.
+
+## Frontend y evidencia
+
+`src/hooks/useInstitutionalActions.ts` usa las tablas tipadas sin crear una
+columna ficticia para evidencia. `registerEvidence()` inserta los campos reales
+de `evidence_log`; el identificador del alumno se usa en la auditoría asociada.
 
 ## Fuera de alcance
 
-- No tocar `DashboardTrabajoSocial.tsx` — requiere PR separado con diseno de persistencia
-- No tocar `DashboardDocente.tsx` — el boton escalar es placeholder intencional
-- No tocar Orientacion v2 — ya completo y funcional
-- No tocar flujo de emergencia (`alertas_emergencia`, `respuestas_alerta_emergencia`) — ya funcional
-- No tocar auth ni perfiles_usuario
-- No regenerar toda la UI de Trabajo Social
+- Cambiar el papel de `sase_alerts` más allá de su uso de observabilidad fuera
+  del flujo SOS operativo.
+- Agregar `student_id` a `evidence_log`.
+- Cambiar el modelo funcional de `alertas_emergencia`.
+- Hacer merge, push, deploy o aplicar manualmente la migración.
 
-## Reglas funcionales
+## Estado de verificación
 
-- Cualquier usuario con rol institucional (docente, tutor, orientacion, trabajo_social, prefectura, direccion, subdireccion, enfermeria, medico_escolar, secretaria, desarrollador, system_admin) puede INSERT en las 5 tablas
-- Cada quien ve SOLO sus propios registros (por `user_id` o `creado_por`)
-- Direccion, Subdireccion, Developer, System_admin ven TODO en SELECT
-- UPDATE solo para direccion/subdireccion/developer/system_admin (excepcion: `citas_padres` tambien para orientacion)
-- `sos_alerts`: todos los roles institucionales pueden INSERT, todos pueden SELECT (visibilidad completa por ser emergencia), UPDATE para quien atiende (ACK/resolver)
-
-## Archivos a crear
-
-| Archivo | Accion |
-|---------|--------|
-| `supabase/migrations/20260612000001_sos_alerts_y_auto_escalation.sql` | Mover desde `_wip/sos/` |
-| `supabase/migrations/20260612000002_rls_tablas_institucionales.sql` | RLS policies para interventions_log, evidence_log, citas_padres, contacts_log, activities_log |
-
-## Archivos a modificar
-
-| Archivo | Cambio |
-|---------|--------|
-| `src/hooks/useInstitutionalActions.ts` | Quitar `as any` en las 10 funciones |
-| `src/types.ts` o `src/supabase/types.ts` | Regenerar tipos (o agregar interfaces manuales para las 6 tablas) |
-| Opcional: `src/store.tsx` | Tipar evidencia_log |
-
-## Prueba minima
-
-```bash
-# 1. Migraciones locales
-supabase db start
-supabase migration up
-
-# 2. TypeScript sin escapes
-pnpm type-check
-# No debe haber errores en useInstitutionalActions.ts ni referencias a tablas sin tipo
-
-# 3. Tests existentes pasan
-pnpm test
-
-# 4. Auditoria de migraciones
-./scripts/audit-migrations.sh
-
-# 5. Lint SQL
-supabase db lint --local
-```
-
-## Prueba end-to-end manual
-
-```
-1. Login como Direccion
-2. Abrir el dashboard de Direccion
-3. Hacer clic en "Escalar caso" con un alumno
-4. Verificar que aparece toast.success y NO error en consola
-5. Ir a Supabase dashboard → SQL editor → SELECT * FROM interventions_log WHERE student_id = '<id>'
-6. Verificar que el registro existe
-7. Repetir con SOS, Cerrar caso, Registrar evidencia
-8. Login como Trabajo Social → verificar que NO puede hacer SELECT de interventions_log de otros
-```
-
-## Plan de merge
-
-```
-1. main ← fix/rls-tablas-institucionales
-2. CI: pnpm install → pnpm lint → pnpm type-check → pnpm test → pnpm build
-3. Migraciones locales OK
-4. Revisar que `_wip/sos/` queda vacio (opcional: borrarlo)
-5. Merge a main
-6. Post-merge: `supabase db push` para aplicar migraciones a produccion
-```
+La implementación está en QA. Este ajuste documental no ejecuta validaciones.
+Las puertas requeridas y los escenarios RLS están descritos en `quickstart.md`.
 
 ## Riesgos
 
-- Si alguna policy es muy restrictiva, el frontend seguira cayendo al catch silencioso. Validar con prueba end-to-end antes del merge.
-- `sos_alerts` tiene pg_cron scheduling que puede fallar si pg_cron no esta habilitado en el proyecto. La migracion ya maneja ese caso con `RAISE NOTICE`.
-- Las policies para `interventions_log` deben permitir INSERT desde cualquier rol institucional, no solo direccion, porque `notifyDepartment()` y `confirmAttention()` tambien escriben ahi.
+- Una diferencia entre la matriz documentada y las políticas SQL puede ampliar
+  lectura institucional o bloquear operaciones legítimas.
+- Un perfil sin estados activos o con rol fuera del catálogo queda denegado por
+  diseño.
+- La restricción de columnas en `perfiles_usuario` puede exponer dependencias
+  cliente existentes que intenten actualizar campos ahora protegidos.
+- La implementación no debe considerarse operativa en producción sin QA,
+  revisión y aplicación autorizada de la migración.

--- a/specs/008-rls-tablas-institucionales/tasks.md
+++ b/specs/008-rls-tablas-institucionales/tasks.md
@@ -1,11 +1,40 @@
-1. Confirmar hallazgos localmente
-2. Crear migracion `20260612000001_sos_alerts_y_auto_escalation.sql` (copiar desde `_wip/sos/`)
-3. Crear migracion `20260612000002_rls_tablas_institucionales.sql` (RLS policies)
-4. Regenerar tipos TypeScript con `supabase gen types typescript --local > src/supabase/types.ts`
-5. Quitar `as any` en `src/hooks/useInstitutionalActions.ts`
-6. Agregar `student_id` al INSERT de `registerEvidence()`
-7. Verificar `src/store.tsx` referencias a evidence_log
-8. `pnpm type-check` sin errores
-9. `pnpm test` pasa
-10. `./scripts/audit-migrations.sh` sin errores
-11. Prueba manual end-to-end (ver spec)
+# Tareas - Spec 008
+
+Estado: Implementado / en QA
+
+## Implementación
+
+- [x] Confirmar `alertas_emergencia` como flujo SOS canónico.
+- [x] Mantener `sase_alerts` fuera del flujo SOS operativo.
+- [x] Confirmar que `evidence_log` no tiene `student_id`.
+- [x] Mantener `registerEvidence()` sobre las columnas reales de
+  `evidence_log`.
+- [x] Implementar RLS en
+  `supabase/migrations/20260701000000_add_rls_policies.sql`.
+- [x] Incorporar autorización fail-closed con `auth.uid()`,
+  `perfiles_usuario.rol`, `estado_cuenta` y `seguridad_status`.
+- [x] Limitar SELECT a registros propios, con acceso global solo para roles
+  explícitamente privilegiados.
+- [x] Definir la excepción de `citas_padres` para creador, `orientacion` y
+  roles privilegiados.
+- [x] Limitar UPDATE a `interventions_log` y `citas_padres`.
+- [x] Restringir UPDATE de `perfiles_usuario` a nombre, teléfono y preferencias.
+- [x] Actualizar `spec.md`, `tasks.md` y `quickstart.md` con la implementación
+  real.
+
+## QA pendiente
+
+- [ ] Ejecutar `./scripts/audit-migrations.sh`.
+- [ ] Ejecutar `supabase db start`.
+- [ ] Ejecutar `supabase db lint --local`.
+- [ ] Ejecutar `pnpm lint`.
+- [ ] Ejecutar `pnpm type-check`.
+- [ ] Ejecutar `pnpm test`.
+- [ ] Ejecutar `pnpm build`.
+- [ ] Validar escenarios RLS de propietario, roles privilegiados,
+  `orientacion`, perfiles inactivos y roles no admitidos.
+- [ ] Confirmar que el flujo SOS persiste exclusivamente en
+  `alertas_emergencia`.
+
+No realizado en esta actualización documental: QA, commit, push, merge o
+deploy.

--- a/supabase/migrations/20260701000000_add_rls_policies.sql
+++ b/supabase/migrations/20260701000000_add_rls_policies.sql
@@ -1,5 +1,5 @@
 -- 2026-07-01: RLS minima y re-ejecutable para tablas institucionales.
--- Usa auth.uid() + perfiles_usuario como fuente de autorizacion.
+-- Usa auth.uid() + perfiles_usuario.rol como fuente de autorizacion.
 
 create schema if not exists private;
 revoke all on schema private from public;
@@ -9,13 +9,30 @@ create or replace function private.is_institutional_actor(allowed_roles text[])
 returns boolean
 language sql
 security definer
-set search_path = public
+set search_path = ''
 stable
 as $$
   select exists (
     select 1
-    from public.perfiles_usuario p
-    where p.id = auth.uid()
+    from public.perfiles_usuario as p
+    where p.id = (select auth.uid())
+      and p.estado_cuenta = 'activo'
+      and p.seguridad_status = 'active'
+      and lower(trim(coalesce(p.rol, p.role, ''))) = any (array[
+        'directivo',
+        'subdireccion',
+        'docente',
+        'docente_tutor',
+        'prefectura',
+        'orientacion',
+        'trabajo_social',
+        'medico_escolar',
+        'udeii',
+        'promotora_lectura',
+        'secretaria',
+        'developer',
+        'system_admin'
+      ]::text[])
       and lower(trim(coalesce(p.rol, p.role, ''))) = any (allowed_roles)
   );
 $$;
@@ -23,178 +40,364 @@ $$;
 revoke all on function private.is_institutional_actor(text[]) from public;
 grant execute on function private.is_institutional_actor(text[]) to authenticated;
 
-ALTER TABLE public.interventions_log ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.evidence_log ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.citas_padres ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.contacts_log ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.activities_log ENABLE ROW LEVEL SECURITY;
+alter table public.interventions_log enable row level security;
+alter table public.evidence_log enable row level security;
+alter table public.citas_padres enable row level security;
+alter table public.contacts_log enable row level security;
+alter table public.activities_log enable row level security;
 
-DROP POLICY IF EXISTS "interventions_log_select" ON public.interventions_log;
-DROP POLICY IF EXISTS "interventions_log_insert" ON public.interventions_log;
-CREATE POLICY "interventions_log_select" ON public.interventions_log
-FOR SELECT
-TO authenticated
-USING (
-  private.is_institutional_actor(array[
-    'directivo',
-    'subdireccion',
-    'orientacion',
-    'trabajo_social',
-    'prefectura',
-    'docente',
-    'secretaria',
-    'udeii'
-  ])
-);
-CREATE POLICY "interventions_log_insert" ON public.interventions_log
-FOR INSERT
-TO authenticated
-WITH CHECK (
-  user_id = auth.uid()
-  and private.is_institutional_actor(array[
-    'directivo',
-    'subdireccion',
-    'orientacion',
-    'trabajo_social',
-    'prefectura',
-    'docente',
-    'secretaria',
-    'udeii'
-  ])
-);
+-- El cliente solo puede actualizar campos de presentacion de su propio perfil.
+revoke update on table public.perfiles_usuario from public, anon, authenticated;
+grant update (nombre_completo, telefono, preferencias_dashboard)
+on table public.perfiles_usuario
+to authenticated;
 
-DROP POLICY IF EXISTS "evidence_log_select" ON public.evidence_log;
-DROP POLICY IF EXISTS "evidence_log_insert" ON public.evidence_log;
-CREATE POLICY "evidence_log_select" ON public.evidence_log
-FOR SELECT
-TO authenticated
-USING (
-  private.is_institutional_actor(array[
+-- UPDATE institucional se limita a las tablas y columnas exigidas por la spec.
+revoke update on table public.interventions_log from public, anon, authenticated;
+grant update (reason, result, notes)
+on table public.interventions_log
+to authenticated;
+
+revoke update on table public.citas_padres from public, anon, authenticated;
+grant update (estado, fecha_cita, motivo, observaciones)
+on table public.citas_padres
+to authenticated;
+
+revoke update on table public.evidence_log from public, anon, authenticated;
+revoke update on table public.contacts_log from public, anon, authenticated;
+revoke update on table public.activities_log from public, anon, authenticated;
+
+drop policy if exists "interventions_log_select" on public.interventions_log;
+drop policy if exists "interventions_log_insert" on public.interventions_log;
+drop policy if exists "interventions_log_update" on public.interventions_log;
+
+create policy "interventions_log_select"
+on public.interventions_log
+for select
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
     'directivo',
     'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
     'orientacion',
     'trabajo_social',
-    'prefectura',
-    'docente',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
     'secretaria',
-    'udeii'
-  ])
-);
-CREATE POLICY "evidence_log_insert" ON public.evidence_log
-FOR INSERT
-TO authenticated
-WITH CHECK (
-  user_id = auth.uid()
-  and private.is_institutional_actor(array[
-    'directivo',
-    'subdireccion',
-    'orientacion',
-    'trabajo_social',
-    'prefectura',
-    'docente',
-    'secretaria',
-    'udeii'
-  ])
+    'developer',
+    'system_admin'
+  ]::text[]))
+  and (
+    user_id = (select auth.uid())
+    or (select private.is_institutional_actor(array[
+      'directivo',
+      'subdireccion',
+      'developer',
+      'system_admin'
+    ]::text[]))
+  )
 );
 
-DROP POLICY IF EXISTS "citas_padres_select" ON public.citas_padres;
-DROP POLICY IF EXISTS "citas_padres_insert" ON public.citas_padres;
-CREATE POLICY "citas_padres_select" ON public.citas_padres
-FOR SELECT
-TO authenticated
-USING (
-  private.is_institutional_actor(array[
+create policy "interventions_log_insert"
+on public.interventions_log
+for insert
+to authenticated
+with check (
+  user_id = (select auth.uid())
+  and (select private.is_institutional_actor(array[
     'directivo',
     'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
     'orientacion',
     'trabajo_social',
-    'prefectura',
-    'docente',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
     'secretaria',
-    'udeii'
-  ])
-);
-CREATE POLICY "citas_padres_insert" ON public.citas_padres
-FOR INSERT
-TO authenticated
-WITH CHECK (
-  creado_por = auth.uid()
-  and private.is_institutional_actor(array[
-    'directivo',
-    'subdireccion',
-    'orientacion',
-    'trabajo_social',
-    'prefectura',
-    'docente',
-    'secretaria',
-    'udeii'
-  ])
+    'developer',
+    'system_admin'
+  ]::text[]))
 );
 
-DROP POLICY IF EXISTS "contacts_log_select" ON public.contacts_log;
-DROP POLICY IF EXISTS "contacts_log_insert" ON public.contacts_log;
-CREATE POLICY "contacts_log_select" ON public.contacts_log
-FOR SELECT
-TO authenticated
-USING (
-  private.is_institutional_actor(array[
+create policy "interventions_log_update"
+on public.interventions_log
+for update
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
     'directivo',
     'subdireccion',
-    'orientacion',
-    'trabajo_social',
-    'prefectura',
-    'docente',
-    'secretaria',
-    'udeii'
-  ])
-);
-CREATE POLICY "contacts_log_insert" ON public.contacts_log
-FOR INSERT
-TO authenticated
-WITH CHECK (
-  user_id = auth.uid()
-  and private.is_institutional_actor(array[
+    'developer',
+    'system_admin'
+  ]::text[]))
+)
+with check (
+  (select private.is_institutional_actor(array[
     'directivo',
     'subdireccion',
-    'orientacion',
-    'trabajo_social',
-    'prefectura',
-    'docente',
-    'secretaria',
-    'udeii'
-  ])
+    'developer',
+    'system_admin'
+  ]::text[]))
 );
 
-DROP POLICY IF EXISTS "activities_log_select" ON public.activities_log;
-DROP POLICY IF EXISTS "activities_log_insert" ON public.activities_log;
-CREATE POLICY "activities_log_select" ON public.activities_log
-FOR SELECT
-TO authenticated
-USING (
-  private.is_institutional_actor(array[
+drop policy if exists "evidence_log_select" on public.evidence_log;
+drop policy if exists "evidence_log_insert" on public.evidence_log;
+drop policy if exists "evidence_log_update" on public.evidence_log;
+
+create policy "evidence_log_select"
+on public.evidence_log
+for select
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
     'directivo',
     'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
     'orientacion',
     'trabajo_social',
-    'prefectura',
-    'docente',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
     'secretaria',
-    'udeii'
-  ])
+    'developer',
+    'system_admin'
+  ]::text[]))
+  and (
+    user_id = (select auth.uid())
+    or (select private.is_institutional_actor(array[
+      'directivo',
+      'subdireccion',
+      'developer',
+      'system_admin'
+    ]::text[]))
+  )
 );
-CREATE POLICY "activities_log_insert" ON public.activities_log
-FOR INSERT
-TO authenticated
-WITH CHECK (
-  user_id = auth.uid()
-  and private.is_institutional_actor(array[
+
+create policy "evidence_log_insert"
+on public.evidence_log
+for insert
+to authenticated
+with check (
+  user_id = (select auth.uid())
+  and (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
+    'secretaria',
+    'developer',
+    'system_admin'
+  ]::text[]))
+);
+
+drop policy if exists "citas_padres_select" on public.citas_padres;
+drop policy if exists "citas_padres_insert" on public.citas_padres;
+drop policy if exists "citas_padres_update" on public.citas_padres;
+
+create policy "citas_padres_select"
+on public.citas_padres
+for select
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
+    'secretaria',
+    'developer',
+    'system_admin'
+  ]::text[]))
+  and (
+    creado_por = (select auth.uid())
+    or (select private.is_institutional_actor(array[
+      'orientacion',
+      'directivo',
+      'subdireccion',
+      'developer',
+      'system_admin'
+    ]::text[]))
+  )
+);
+
+create policy "citas_padres_insert"
+on public.citas_padres
+for insert
+to authenticated
+with check (
+  creado_por = (select auth.uid())
+  and (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
+    'secretaria',
+    'developer',
+    'system_admin'
+  ]::text[]))
+);
+
+create policy "citas_padres_update"
+on public.citas_padres
+for update
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
     'directivo',
     'subdireccion',
     'orientacion',
-    'trabajo_social',
-    'prefectura',
+    'developer',
+    'system_admin'
+  ]::text[]))
+)
+with check (
+  (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'orientacion',
+    'developer',
+    'system_admin'
+  ]::text[]))
+);
+
+drop policy if exists "contacts_log_select" on public.contacts_log;
+drop policy if exists "contacts_log_insert" on public.contacts_log;
+drop policy if exists "contacts_log_update" on public.contacts_log;
+
+create policy "contacts_log_select"
+on public.contacts_log
+for select
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
     'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
     'secretaria',
-    'udeii'
-  ])
+    'developer',
+    'system_admin'
+  ]::text[]))
+  and (
+    user_id = (select auth.uid())
+    or (select private.is_institutional_actor(array[
+      'directivo',
+      'subdireccion',
+      'developer',
+      'system_admin'
+    ]::text[]))
+  )
+);
+
+create policy "contacts_log_insert"
+on public.contacts_log
+for insert
+to authenticated
+with check (
+  user_id = (select auth.uid())
+  and (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
+    'secretaria',
+    'developer',
+    'system_admin'
+  ]::text[]))
+);
+
+drop policy if exists "activities_log_select" on public.activities_log;
+drop policy if exists "activities_log_insert" on public.activities_log;
+drop policy if exists "activities_log_update" on public.activities_log;
+
+create policy "activities_log_select"
+on public.activities_log
+for select
+to authenticated
+using (
+  (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
+    'secretaria',
+    'developer',
+    'system_admin'
+  ]::text[]))
+  and (
+    user_id = (select auth.uid())
+    or (select private.is_institutional_actor(array[
+      'directivo',
+      'subdireccion',
+      'developer',
+      'system_admin'
+    ]::text[]))
+  )
+);
+
+create policy "activities_log_insert"
+on public.activities_log
+for insert
+to authenticated
+with check (
+  user_id = (select auth.uid())
+  and (select private.is_institutional_actor(array[
+    'directivo',
+    'subdireccion',
+    'docente',
+    'docente_tutor',
+    'prefectura',
+    'orientacion',
+    'trabajo_social',
+    'medico_escolar',
+    'udeii',
+    'promotora_lectura',
+    'secretaria',
+    'developer',
+    'system_admin'
+  ]::text[]))
 );

--- a/supabase/migrations/20260701000000_add_rls_policies.sql
+++ b/supabase/migrations/20260701000000_add_rls_policies.sql
@@ -18,7 +18,7 @@ as $$
     where p.id = (select auth.uid())
       and p.estado_cuenta = 'activo'
       and p.seguridad_status = 'active'
-      and lower(trim(coalesce(p.rol, p.role, ''))) = any (array[
+      and nullif(lower(trim(p.rol)), '') = any (array[
         'directivo',
         'subdireccion',
         'docente',
@@ -33,7 +33,7 @@ as $$
         'developer',
         'system_admin'
       ]::text[])
-      and lower(trim(coalesce(p.rol, p.role, ''))) = any (allowed_roles)
+      and nullif(lower(trim(p.rol)), '') = any (allowed_roles)
   );
 $$;
 


### PR DESCRIPTION
## Resumen

Follow-up posterior al PR #93 para endurecer políticas RLS institucionales y alinear la documentación del frente 008.

## Cambios

- Endurece la migración `20260701000000_add_rls_policies.sql`.
- Corrige documentación/specs del frente `008-rls-tablas-institucionales`.
- No toca el hook.
- No toca PR #91.
- No hace deploy.

## QA local

- type-check: PASA
- lint: PASA
- test: PASA
- build: PASA

## Alcance

Incluye solo:

- `supabase/migrations/20260701000000_add_rls_policies.sql`
- `specs/008-rls-tablas-institucionales/quickstart.md`
- `specs/008-rls-tablas-institucionales/spec.md`
- `specs/008-rls-tablas-institucionales/tasks.md`