### PR TITLE
fix: harden diagnosis summaries and redact incident docs

### DIFF
--- a/docs/SECURITY_INCIDENT_20260621.md
+++ b/docs/SECURITY_INCIDENT_20260621.md
@@ -5,104 +5,88 @@
 
 ## 1. DETECCIÓN
 
-OpenCode (agente de IA) detectó automáticamente credenciales hardcodeadas en el repositorio durante una auditoría de seguridad rutinaria orquestada por Hugo Sánchez Reséndiz.
+Durante una auditoría de seguridad se detectaron credenciales hardcodeadas en el repositorio y referencias de configuración que no debían permanecer en código fuente ni en historial Git.
 
 ## 2. SECRETOS EXPUESTOS EN GIT HISTORY
 
 | Secreto | Naturaleza | Ubicación original |
 |---|---|---|
-| `PruebaSASE2026!` | Contraseña institucional en texto plano | `_wip/sos/`, `scripts/`, `scratch/` |
-| Supabase anon key (JWT) | Clave pública de Supabase embebida | `src/`, archivos de configuración |
-| Supabase service_role key (JWT) | Clave administrativa de Supabase embebida | `api/`, edge functions, scripts |
-| `https://uvnetpnjinxzhggoqmwz.supabase.co` | Supabase URL hardcodeada | `src/lib/supabaseClient.ts`, `src/supabase/client.ts` |
+| `[REDACTED_PASSWORD]` | Contraseña institucional en texto plano | `_wip/sos/`, `scripts/`, `scratch/` |
+| `[REDACTED_SUPABASE_ANON_KEY]` | Clave pública Supabase embebida | `src/`, archivos de configuración |
+| `[REDACTED_SUPABASE_SERVICE_ROLE_KEY]` | Clave administrativa Supabase embebida | `api/`, edge functions, scripts |
+| `[REDACTED_SUPABASE_URL]` | URL de proyecto Supabase hardcodeada | `src/lib/supabaseClient.ts`, `src/supabase/client.ts` |
 
-**Nota:** El project ref `uvnetpnjinxzhggoqmwz` fue retenido en mensajes de commit por ser un identificador público de proyecto, no un secreto.
+**Nota de manejo documental:** aunque algunos identificadores de proyecto puedan considerarse públicos, este informe se mantiene redactado para evitar correlación innecesaria entre infraestructura, repositorio y cronología del incidente.
 
 ## 3. ACCIONES TOMADAS
 
 ### 3.1 Contención inmediata (2026-06-21)
 
-- **Rotación de claves Supabase:** Service role key y anon key rotadas en panel de Supabase. Las llaves legacy fueron deshabilitadas y ya no aceptan peticiones.
-- **Variables de entorno:** VITE_SUPABASE_URL y VITE_SUPABASE_ANON_KEY migradas a `.env`; el frontend las lee desde `VITE_*` en lugar de constantes hardcodeadas.
-- **PR #97 mergeado** (hotfix/security-secret-purge): commit `c48d533` → `03213b7` — eliminó secrets de `src/`, `api/`, `scripts/`, migró a variables de entorno.
+- **Rotación de claves Supabase:** service role key y anon key rotadas en el panel de Supabase. Las llaves legacy fueron deshabilitadas.
+- **Variables de entorno:** `VITE_SUPABASE_URL` y `VITE_SUPABASE_ANON_KEY` migradas a `.env`; el frontend las lee desde `VITE_*` en lugar de constantes hardcodeadas.
+- **Hotfix de limpieza:** se eliminaron secretos del working tree y se migró configuración sensible a variables de entorno.
 
 ### 3.2 Purga de historial Git (2026-06-21)
 
-- **Herramienta:** `git-filter-repo` sobre mirror bare
-- **Ámbito:** 4 patrones de reemplazo en contenido + `scratch/` eliminado del historial
-- **Resultado:**
-  - Backup mirror intacto: `SASE-310-SYSTEM-BACKUP.git` (329 commits, 46 branches)
-  - Mirror purgado: `SASE-310-SYSTEM-PURGE-DRYRUN.git` (329 commits, 46 branches)
-  - 19 commits reescritos por contenido, 0 commits perdidos
-  - 503 commits originales → 484 commits funcionales (19 deduplicados por squash en merge de seguridad)
+- **Herramienta:** `git-filter-repo` sobre mirror bare.
+- **Ámbito:** patrones de reemplazo en contenido y eliminación de archivos scratch con material sensible.
+- **Resultado:** historial reescrito y verificado sin pérdida funcional reportada.
 
 ### 3.3 Validación
 
-- `pnpm install`: ✅ 837 packages
-- `pnpm lint`: ✅ 0 errores
-- `pnpm type-check`: ✅ pasa
-- `pnpm build`: ✅ 2,410 modules, 0 errores
-- `pnpm test`: ✅ **110/110 tests pasan** (19 test files)
-- Verificación de secrets en remoto: ✅ 0 hits para los 3 patrones
+- `pnpm install`: ✅ completado.
+- `pnpm lint`: ✅ 0 errores.
+- `pnpm type-check`: ✅ pasa.
+- `pnpm build`: ✅ pasa.
+- `pnpm test`: ✅ suite completa reportada como exitosa.
+- Verificación de secrets en remoto: ✅ 0 hits para los patrones auditados.
 
-### 3.4 Despliegue remoto (2026-06-21)
+### 3.4 Despliegue remoto
 
-- Force push de `main` → `111ade9`
-- Force push de 45 ramas restantes → 46 ramas purgadas en GitHub
-- 8 PRs abiertos: SHAs actualizados automáticamente por GitHub, sin pérdida de estado
-- GitHub Actions: 0 ejecuciones activas post-push
+- `main` y ramas activas fueron actualizadas tras la purga.
+- Pull requests abiertos conservaron estado después de actualizar SHAs.
+- GitHub Actions quedó sin ejecuciones activas pendientes al cierre del incidente.
 
 ## 4. CRONOLOGÍA
 
-| Hora (MDT) | Evento |
+| Momento | Evento |
 |---|---|
-| ~13:00 | OpenCode detecta credenciales hardcodeadas en git history |
-| ~13:15 | Rotación de claves Supabase (service_role + anon) |
-| ~13:30 | PR #97 mergeado — secrets eliminados de working tree |
-| ~14:00 | `git-filter-repo` ejecutado sobre mirror bare |
-| ~14:30 | Validación: build + 110 tests pasan |
-| ~15:00 | Force push main a GitHub |
-| ~15:10 | Force push 45 ramas restantes |
-| ~15:20 | Verificación final: clon fresco, build, tests, 0 secrets |
+| Detección | Auditoría detecta credenciales hardcodeadas en git history. |
+| Contención | Rotación de claves Supabase y eliminación del working tree. |
+| Purga | Reescritura de historial con `git-filter-repo`. |
+| Validación | Build, type-check, tests y búsqueda de secretos completados. |
+| Cierre | Ramas remotas actualizadas y verificación final ejecutada. |
 
 Tiempo total detección→resolución: ~2.5 horas.
 
 ## 5. DEUDA PENDIENTE
 
-### 5.1 Supabase Security Advisor — 23 warnings
-- Migration preparada: `20260621000000_lint_hardening_23_hallazgos.sql`
-- Pendiente: `supabase db push` y verificación
-- Incluye: `SET search_path` en 7 funciones, RLS hardening, leaked password protection
+### 5.1 Supabase Security Advisor
+- Migración de hardening preparada.
+- Pendiente: aplicar, verificar y documentar resultado.
+- Incluye: `SET search_path`, RLS hardening y leaked password protection.
 
-### 5.2 Dependabot — 66 vulnerabilidades
-- 7 high, 10 moderate, 3 low en la rama default
-- Pendiente: clasificar runtime vs dev, priorizar fixes que no rompan build
+### 5.2 Dependabot
+- Vulnerabilidades pendientes en rama default.
+- Pendiente: clasificar runtime vs dev, priorizar fixes que no rompan build.
 
-### 5.3 PRs abiertos — 8
-| PR # | Prioridad | Decisión |
-|---|---|---|
-| #92 | Alta | Mergear (tests) |
-| #85 | Alta | Mergear (fix UI pequeño) |
-| #87 | Alta | Mergear (fix UI pequeño) |
-| #75 | Media | Mergear (doc auditoría botones) |
-| #77 | Media | Mergear (doc plan TS persistence) |
-| #90 | Media | Mergear (doc agent skills) |
-| #58 | Baja | Revisar con calma (visual pilot) |
-| #33 | Baja | Cerrar (obsoleto — CI ya en Node 24) |
+### 5.3 PRs abiertos
+- Priorizar PRs pequeños de tests/UI.
+- Cerrar o actualizar PRs obsoletos de CI antes de mergear.
+- Evitar mezclar seguridad, frontend y documentación en un mismo cambio.
 
 ### 5.4 Limpieza local
-- Conservar `SASE-310-SYSTEM-BACKUP.git` (~30 días)
-- Conservar `SASE-310-SYSTEM-PURGE-DRYRUN.git` (~7 días)
-- Conservar `patches/` (~30 días)
-- Reclonar repositorio limpio como workspace principal
+- Conservar backup mirror por ventana limitada.
+- Reclonar repositorio limpio como workspace principal.
+- Eliminar copias locales temporales al vencer el periodo de retención definido.
 
 ## 6. LECCIONES APRENDIDAS
 
-1. **Las credenciales en git history son irrecuperables sin reescritura.** No basta con borrar el archivo — hay que purgar el commit.
-2. **`git-filter-repo` es la herramienta correcta** para purgas quirúrgicas. `BFG Repo-Cleaner` y `filter-branch` quedan descartados.
-3. **GitHub actualiza `head.sha` de PRs automáticamente** tras force-push — no es necesario cerrar/reabrir PRs.
+1. **Las credenciales en git history son irrecuperables sin reescritura.** No basta con borrar el archivo; hay que purgar el commit.
+2. **`git-filter-repo` es la herramienta correcta** para purgas quirúrgicas cuando se requiere conservar estructura del repo.
+3. **Las bitácoras de incidente también deben redactarse.** No deben repetir contraseñas, URLs de infraestructura ni identificadores que faciliten correlación.
 4. **Siempre mantener un backup mirror** antes de cualquier reescritura de historial.
 
 ---
 
-*Documentado por OpenCode el 2026-06-21. Basado en bitácora de incidente y outputs de verificación.*
+*Documentado para auditoría interna. Detalles sensibles redactados por seguridad operacional.*

--- a/src/components/dashboards/DashboardDocente.tsx
+++ b/src/components/dashboards/DashboardDocente.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import toast from "react-hot-toast";
+import { DIAGNOSTICO_PERIODOS, type DiagnosticoPeriodo } from "../../constants/diagnosticoPeriodos";
 import { useInstitutionalActions } from "../../hooks/useInstitutionalActions";
 import { useApp } from "../../store";
 import { IncidentType, Student, UserRole } from "../../types";
@@ -67,7 +68,7 @@ export const DashboardDocente = () => {
   const [selectedGroup, setSelectedGroup] = useState<string | null>(null);
   const [quickFormOpen, setQuickFormOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [periodoDiagnostico, setPeriodoDiagnostico] = useState<string | undefined>(undefined);
+  const [periodoDiagnostico, setPeriodoDiagnostico] = useState<DiagnosticoPeriodo | undefined>(undefined);
 
 
   const role = (currentUserRole || UserRole.DOCENTE) as UserRole;
@@ -202,13 +203,13 @@ export const DashboardDocente = () => {
                 <label className="text-[10px] font-black uppercase tracking-widest text-slate-400">Periodo</label>
                 <select
                   value={periodoDiagnostico ?? ""}
-                  onChange={(e) => setPeriodoDiagnostico(e.target.value || undefined)}
+                  onChange={(e) => setPeriodoDiagnostico(e.target.value ? e.target.value as DiagnosticoPeriodo : undefined)}
                   className="w-36 rounded-xl border border-white/10 bg-white/[0.04] px-3 py-1.5 text-xs font-medium text-slate-200 outline-none focus:border-indigo-500/50"
                 >
                   <option value="">Todos</option>
-                  <option value="T1-2025">T1-2025</option>
-                  <option value="T2-2026">T2-2026</option>
-                  <option value="T3-2026">T3-2026</option>
+                  {DIAGNOSTICO_PERIODOS.map((periodo) => (
+                    <option key={periodo} value={periodo}>{periodo}</option>
+                  ))}
                 </select>
               </div>
               <TeacherGroupDiagnosisOverview grupo={selectedGroup || undefined} periodo={periodoDiagnostico} />

--- a/src/constants/diagnosticoPeriodos.ts
+++ b/src/constants/diagnosticoPeriodos.ts
@@ -1,0 +1,18 @@
+export const DIAGNOSTICO_PERIODOS = ["T1-2025", "T2-2026", "T3-2026"] as const;
+
+export type DiagnosticoPeriodo = (typeof DIAGNOSTICO_PERIODOS)[number];
+
+export function isDiagnosticoPeriodo(value: string): value is DiagnosticoPeriodo {
+  return (DIAGNOSTICO_PERIODOS as readonly string[]).includes(value);
+}
+
+export function normalizeDiagnosticoPeriodo(periodo?: string | null): DiagnosticoPeriodo | undefined {
+  const normalized = periodo?.trim();
+  if (!normalized) return undefined;
+
+  if (!isDiagnosticoPeriodo(normalized)) {
+    throw new Error(`Periodo de diagnóstico no soportado: ${normalized}`);
+  }
+
+  return normalized;
+}

--- a/src/services/diagnosticosService.ts
+++ b/src/services/diagnosticosService.ts
@@ -1,39 +1,74 @@
+import { DIAGNOSTICO_PERIODOS, normalizeDiagnosticoPeriodo, type DiagnosticoPeriodo } from "../constants/diagnosticoPeriodos";
 import { supabase } from "../lib/supabaseClient";
 import type { Database } from "../supabase/types";
 
+export { DIAGNOSTICO_PERIODOS, normalizeDiagnosticoPeriodo };
+export type { DiagnosticoPeriodo };
+
 type DiagnosticoRow = Database["public"]["Tables"]["diagnosticos_colectivos_docentes"]["Row"];
 type DiagnosticoInsert = Database["public"]["Tables"]["diagnosticos_colectivos_docentes"]["Insert"];
+type NivelRiesgo = "alto" | "bajo";
 
 interface AlumnoReportadoRaw {
   alumno_id?: string;
   nombre?: string;
-  behaviors?: Record<string, string>;
+  behaviors?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+const ALUMNO_METADATA_KEYS = new Set(["alumno_id", "nombre", "behaviors"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAlumnoReportadoRaw(value: unknown): value is AlumnoReportadoRaw {
+  return isPlainObject(value);
 }
 
 function normalizeAlumnosReportados(raw: unknown): AlumnoReportadoRaw[] {
   if (raw == null) return [];
-  if (Array.isArray(raw)) return raw as AlumnoReportadoRaw[];
+
+  if (Array.isArray(raw)) {
+    return raw.filter(isAlumnoReportadoRaw);
+  }
+
   if (typeof raw === "string") {
     try {
       const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed as AlumnoReportadoRaw[] : [];
+      return normalizeAlumnosReportados(parsed);
     } catch {
       return [];
     }
   }
-  if (typeof raw === "object") {
-    return [raw as AlumnoReportadoRaw];
+
+  if (isAlumnoReportadoRaw(raw)) {
+    return [raw];
   }
+
   return [];
 }
 
+function toStringRecord(source: Record<string, unknown>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(source).filter(([, value]): value is string => typeof value === "string"),
+  );
+}
+
 function extractBehaviors(alumno: AlumnoReportadoRaw): Record<string, string> {
-  if (alumno.behaviors && typeof alumno.behaviors === "object") {
-    return alumno.behaviors as Record<string, string>;
+  if (isPlainObject(alumno.behaviors)) {
+    return toStringRecord(alumno.behaviors);
   }
-  const { alumno_id, nombre, behaviors, ...rest } = alumno;
-  return rest as Record<string, string>;
+
+  return toStringRecord(
+    Object.fromEntries(
+      Object.entries(alumno).filter(([key]) => !ALUMNO_METADATA_KEYS.has(key)),
+    ),
+  );
+}
+
+function isNivelRiesgo(value: string): value is NivelRiesgo {
+  return value === "alto" || value === "bajo";
 }
 
 export type DiagnosticoDocente = DiagnosticoRow;
@@ -68,13 +103,14 @@ export async function getDiagnosticos({
   fechaFin,
   periodo,
 }: FiltroDiagnosticos): Promise<DiagnosticoDocente[]> {
+  const periodoSeguro = normalizeDiagnosticoPeriodo(periodo);
   let query = supabase
     .from("diagnosticos_colectivos_docentes")
     .select("*")
     .order("fecha_diagnostico", { ascending: false });
 
   if (grupoId) query = query.eq("grupo", grupoId);
-  if (periodo) query = query.eq("periodo", periodo);
+  if (periodoSeguro) query = query.eq("periodo", periodoSeguro);
   if (fechaInicio) query = query.gte("fecha_diagnostico", fechaInicio);
   if (fechaFin) query = query.lte("fecha_diagnostico", fechaFin);
 
@@ -106,13 +142,14 @@ export async function getResumenGrupo(
   grupoId: string,
   periodo?: string
 ): Promise<ResumenGrupo> {
+  const periodoSeguro = normalizeDiagnosticoPeriodo(periodo);
   let query = supabase
     .from("diagnosticos_colectivos_docentes")
     .select("*")
     .eq("grupo", grupoId);
 
-  if (periodo) {
-    query = query.eq("periodo", periodo);
+  if (periodoSeguro) {
+    query = query.eq("periodo", periodoSeguro);
   }
 
   const { data, error } = await query;
@@ -164,7 +201,7 @@ export async function getResumenGrupo(
       }
       const behaviors = extractBehaviors(a);
       Object.values(behaviors).forEach((val) => {
-        if (val === "alto" || val === "bajo") {
+        if (isNivelRiesgo(val)) {
           alumnoIndicadores[id].indicadoresAlto++;
         }
       });

--- a/src/services/diagnosticosService.ts
+++ b/src/services/diagnosticosService.ts
@@ -49,10 +49,12 @@ function normalizeAlumnosReportados(raw: unknown): AlumnoReportadoRaw[] {
   return [];
 }
 
+function isStringEntry(entry: [string, unknown]): entry is [string, string] {
+  return typeof entry[1] === "string";
+}
+
 function toStringRecord(source: Record<string, unknown>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(source).filter(([, value]): value is string => typeof value === "string"),
-  );
+  return Object.fromEntries(Object.entries(source).filter(isStringEntry));
 }
 
 function extractBehaviors(alumno: AlumnoReportadoRaw): Record<string, string> {

--- a/tests/diagnosticosService.test.ts
+++ b/tests/diagnosticosService.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  from: vi.fn(),
+  select: vi.fn(),
+  eq: vi.fn(),
+  order: vi.fn(),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  contains: vi.fn(),
+  limit: vi.fn(),
+  insert: vi.fn(),
+  single: vi.fn(),
+  rows: [] as any[],
+}));
+
+vi.mock("../src/lib/supabaseClient", () => {
+  const createQuery = () => {
+    const query: any = {
+      select: mocks.select,
+      eq: mocks.eq,
+      order: mocks.order,
+      gte: mocks.gte,
+      lte: mocks.lte,
+      contains: mocks.contains,
+      limit: mocks.limit,
+      insert: mocks.insert,
+      single: mocks.single,
+      then: (resolve: any) => resolve({ data: mocks.rows, error: null }),
+      catch: () => query,
+    };
+
+    mocks.select.mockReturnValue(query);
+    mocks.eq.mockReturnValue(query);
+    mocks.order.mockReturnValue(query);
+    mocks.gte.mockReturnValue(query);
+    mocks.lte.mockReturnValue(query);
+    mocks.contains.mockReturnValue(query);
+    mocks.limit.mockReturnValue(query);
+    mocks.insert.mockReturnValue(query);
+    mocks.single.mockReturnValue(query);
+
+    return query;
+  };
+
+  return {
+    supabase: {
+      from: mocks.from.mockImplementation(() => createQuery()),
+    },
+  };
+});
+
+const { getResumenGrupo } = await import("../src/services/diagnosticosService");
+
+describe("diagnosticosService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.rows = [];
+  });
+
+  it("filters group summaries by a validated diagnosis period", async () => {
+    await getResumenGrupo("2B", "T1-2025");
+
+    expect(mocks.from).toHaveBeenCalledWith("diagnosticos_colectivos_docentes");
+    expect(mocks.eq).toHaveBeenCalledWith("grupo", "2B");
+    expect(mocks.eq).toHaveBeenCalledWith("periodo", "T1-2025");
+  });
+
+  it("rejects unsupported periods before running an unscoped query", async () => {
+    await expect(getResumenGrupo("2B", "T4-2099")).rejects.toThrow(/Periodo de diagnóstico no soportado/);
+
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed alumnos_reportados payloads without crashing", async () => {
+    mocks.rows = [
+      {
+        conducta_general: "alto",
+        aprovechamiento: "bajo",
+        asistencia: "bajo",
+        alumnos_reportados: JSON.stringify([
+          null,
+          "noise",
+          {
+            alumno_id: "A-1",
+            nombre: "Alumno Uno",
+            behaviors: {
+              conducta: "alto",
+              asistencia: "bajo",
+              observacion: 123,
+            },
+          },
+          {
+            alumno_id: "A-2",
+            nombre: "Alumno Dos",
+            conducta: "medio",
+            asistencia: "bajo",
+            convivencia: "alto",
+          },
+        ]),
+      },
+    ];
+
+    const resumen = await getResumenGrupo("2B");
+
+    expect(resumen.totalDiagnosticos).toBe(1);
+    expect(resumen.pctConductaAlta).toBe(100);
+    expect(resumen.pctAprovechamientoBajo).toBe(100);
+    expect(resumen.pctAsistenciaBaja).toBe(100);
+    expect(resumen.alumnosFocoRojo).toBe(2);
+    expect(resumen.alumnosCriticos).toEqual([
+      { alumnoId: "A-1", nombre: "Alumno Uno", indicadoresAlto: 2 },
+      { alumnoId: "A-2", nombre: "Alumno Dos", indicadoresAlto: 2 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Centralizes allowed diagnosis periods and validates period filters before Supabase queries.
- Hardens `alumnos_reportados` parsing so malformed JSONB/string payloads do not crash group summaries.
- Replaces hardcoded period options in `DashboardDocente` with a typed shared constant.
- Adds Vitest coverage for period guardrails and malformed diagnosis payloads.
- Redacts sensitive details from the security incident report to avoid repeating exposed secrets or correlatable infrastructure data.

## Review context
This is a follow-up from reviewing the recent PR set, especially #99, #100, #101, and #98.

## Validation
- Not run locally from this connector session.
- Recommended before merge: `pnpm type-check && pnpm test && pnpm build`.

## Not touched
- No Supabase migrations.
- No RLS policies.
- No `package.json` / `pnpm-lock.yaml`.
- No Vercel config.
