### PR TITLE
fix: check institutional action update errors

### DIFF
--- a/src/hooks/useInstitutionalActions.ts
+++ b/src/hooks/useInstitutionalActions.ts
@@ -88,10 +88,11 @@ export const useInstitutionalActions = () => {
         if (error) throw error;
 
         // Actualizar estado del alumno si está en observación
-        await supabase
+        const { error: updateError } = await supabase
           .from("alumnos")
           .update({ estado_semaforo: CaseState.INTERVENCION })
           .eq("id", studentId);
+        if (updateError) throw updateError;
 
         addNotification({
           title: "🚨 CASO ESCALADO",


### PR DESCRIPTION
## Resumen

Extrae el fix mínimo del PR #103 en una rama limpia.

## Cambios

- \escalateCase\: ahora verifica el error de \lumnos.update()\.
- \eopenCase\: ya tenía manejo de error, sin cambios.
- \egisterEvidence\: mantiene el schema actual de \evidence_log\ sin insertar \student_id\.
- \studentId\ se conserva para \logAudit\.

## No incluido

- No se mergea PR #103.
- No se tocan docs, dashboards, tests, migraciones/RLS.
- No deploy.

## QA

- type-check: PASS
- lint: PASS (0 errors)
- test: PASS (55/55 files, 253/253)
- build: PASS