### PR TITLE
fix(SasitoAssistant): limpiar timer proactivo en unmount y eliminar dragConstraints inválido

### DIFF
--- a/src/components/ai/SasitoAssistant.tsx
+++ b/src/components/ai/SasitoAssistant.tsx
@@ -68,6 +68,7 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
   const currentUserName = currentUserProfile?.nombre_completo || currentUserProfile?.full_name || '';
   
   const constraintsRef = useRef(null);
+  const proactiveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (minimal || isWidgetMode || suppressSuggestions) return;
@@ -164,10 +165,14 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
         const suggestion = saseSuggestions[Math.floor(Math.random() * saseSuggestions.length)];
         setCurrentSuggestion(suggestion);
         if (suggestion.state) setLocalState(suggestion.state);
-        setTimeout(() => setCurrentSuggestion(null), 6000);
+        if (proactiveTimerRef.current) clearTimeout(proactiveTimerRef.current);
+        proactiveTimerRef.current = setTimeout(() => setCurrentSuggestion(null), 6000);
       }
     }, 90000);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      if (proactiveTimerRef.current) clearTimeout(proactiveTimerRef.current);
+    };
   }, [minimal, suppressSuggestions, isBubbleExpanded, isChatOpen, saseSuggestions]);
 
   const INTENT_RULES = [
@@ -467,7 +472,7 @@ export const SasitoAssistant: React.FC<SasitoProps> = ({ minimal = false, isWidg
         <motion.div 
           id="sasito-assistant-anchor"
           drag
-          dragConstraints={constraintsRef}
+
           dragElastic={0.02}
           dragMomentum={false}
           onDragStart={() => setShowDragHint(false)}


### PR DESCRIPTION
## Descripción

Fix mínimo extraído de PR #104 (contaminado). Corrige dos problemas en SasitoAssistant:

### 1. Timer leak en sugerencias proactivas
- El \setTimeout\ interno que oculta la sugerencia tras 6s no se limpiaba entre ciclos del intervalo de 90s, acumulando timers huérfanos
- Tampoco se limpiaba en unmount del componente
- Solución: \proactiveTimerRef\ con limpieza en cada nuevo tick y en el return del \useEffect\

### 2. dragConstraints inválido
- \dragConstraints={constraintsRef}\ apuntaba al mismo \motion.div\ contenedor que se está arrastrando, causando constraints nulos/cíclicos que rompían el arrastre
- Solución: eliminar la prop

## QA
- ✅ \pnpm type-check\ — sin errores
- ✅ \pnpm lint\ — 0 errores, 4 warnings preexistentes no relacionados
- ✅ \pnpm test\ — 55/55 files, 253/253 tests
- ✅ \pnpm build\ — build exitoso